### PR TITLE
Allow arbitary level edits for plando purposes

### DIFF
--- a/src/mars_patcher/data/schema.json
+++ b/src/mars_patcher/data/schema.json
@@ -448,7 +448,38 @@
             "type": "boolean",
             "description": "When enabled, starts you with a map where all unexplored items and non-visited tiles have a gray background. This is different from the downloaded map stations where there, the full tile is gray.",
             "default": false
+        },
+        "LevelEdits": {
+            "type": "object",
+            "description": "Specifies room edits that should be done. These will be applied last.",
+            "propertyNames": {
+                "description": "Specifies the Area ID.",
+                "$ref": "#/$defs/AreaIDKey"
+            },
+            "additionalProperties": {
+                "patternProperties": {
+                    "[0-9]+": {
+                        "description": "Specifies the Room ID.",
+                        "properties": {
+                            "BG1": {
+                                "description": "The BG1 layer that should be edited.",
+                                "$ref": "#/$defs/BlockLayer"
+                            },
+                            "BG2": {
+                                "description": "The BG2 layer that should be edited.",
+                                "$ref": "#/$defs/BlockLayer"
+                            },
+                            "Clipdata": {
+                                "description": "The Clipdata layer that should be edited.",
+                                "$ref": "#/$defs/BlockLayer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                }
+            }
         }
+        
     },
     "required": ["SeedHash", "Locations", "RequiredMetroidCount"],
     "$defs": {
@@ -466,6 +497,10 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 6
+        },
+        "AreaIDKey": {
+            "type": "string",
+            "enum": ["0", "1", "2", "3", "4", "5", "6"]
         },
         "SectorID": {
             "type": "integer",
@@ -652,6 +687,27 @@
                 "Italian",
                 "Spanish"
             ]
+        },
+        "BlockLayer": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "X": {
+                        "$ref": "#/$defs/TypeU8",
+                        "description": "The X position in the room that should get edited."
+                    },
+                    "Y": {
+                        "$ref": "#/$defs/TypeU8",
+                        "description": "The Y position in the room that should get edited."
+                    },
+                    "Value": {
+                        "$ref": "#/$defs/TypeU8",
+                        "description": "That value that should be used to edit the room. For backgrounds, this is calculated via `((Row-1) * ColumnsInTileset) + (Column-1)`."
+                    }
+                }
+            }   
         }
     }
 }

--- a/src/mars_patcher/data/schema.json
+++ b/src/mars_patcher/data/schema.json
@@ -493,6 +493,11 @@
             "minimum": 0,
             "maximum": 255
         },
+        "TypeU16": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 65535 
+        },
         "AreaID": {
             "type": "integer",
             "minimum": 0,
@@ -703,7 +708,7 @@
                         "description": "The Y position in the room that should get edited."
                     },
                     "Value": {
-                        "$ref": "#/$defs/TypeU8",
+                        "$ref": "#/$defs/TypeU16",
                         "description": "That value that should be used to edit the room. For backgrounds, this is calculated via `((Row-1) * ColumnsInTileset) + (Column-1)`."
                     }
                 }

--- a/src/mars_patcher/level_edits.py
+++ b/src/mars_patcher/level_edits.py
@@ -1,0 +1,36 @@
+from mars_patcher.rom import Rom
+from typing import Callable
+from mars_patcher.room_entry import RoomEntry
+
+
+def apply_level_edits(rom: Rom, edit_dict: dict) -> None:
+    # Go through every area
+    for area, rooms in edit_dict.items():
+        # Go through every room
+        for room, layers in rooms.items():
+            r = RoomEntry(rom, int(area), int(room))
+            
+            # Go through every layer
+            for layer, changes in layers.items():
+                if layer == "BG1":
+                    load = r.load_bg1
+                    edit = r.set_bg1_block
+                    clean = r.write_bg1
+                elif layer == "BG2":
+                    load = r.load_bg2
+                    edit = r.set_bg2_block
+                    clean = r.write_bg2
+                elif layer == "Clipdata":
+                    load = r.load_clip
+                    edit= r.set_clip_block
+                    clean= r.write_clip
+                else:
+                    ValueError("Unsupported Block Layer")
+
+                # Load layer, do every edit that's provided and write back.
+                load()
+                for change in changes:
+                    edit(change["Value"], change["X"], change["Y"])
+                clean()
+
+            

--- a/src/mars_patcher/patcher.py
+++ b/src/mars_patcher/patcher.py
@@ -8,6 +8,7 @@ from mars_patcher.credits import write_credits
 from mars_patcher.data import get_data_path
 from mars_patcher.door_locks import set_door_locks
 from mars_patcher.item_patcher import ItemPatcher, set_required_metroid_count, set_tank_increments
+from mars_patcher.level_edits import apply_level_edits
 from mars_patcher.locations import LocationSettings
 from mars_patcher.misc_patches import (
     disable_demos,
@@ -128,6 +129,9 @@ def patch(input_path: str,
         apply_unexplored_map(rom)
 
     write_seed_hash(rom, patch_data["SeedHash"])
+
+    if patch_data.get("LevelEdits"):
+        apply_level_edits(rom, patch_data["LevelEdits"])
 
     rom.save(output_path)
     status_update(-1, f"Output written to {output_path}")

--- a/src/mars_patcher/room_entry.py
+++ b/src/mars_patcher/room_entry.py
@@ -78,6 +78,8 @@ class BlockLayer:
 
     def set_block_value(self, value: int, x: int, y: int) -> None:
         idx = (y * self.width + x) * 2
+        if idx >= len(self.block_data):
+            raise IndexError(f"Block coordinate ({x}, {y}) is out of bounds! Room size: ({self.width}, {self.height})")
         self.block_data[idx] = value & 0xFF
         self.block_data[idx + 1] = value >> 8
 

--- a/src/mars_patcher/room_entry.py
+++ b/src/mars_patcher/room_entry.py
@@ -74,6 +74,8 @@ class BlockLayer:
 
     def get_block_value(self, x: int, y: int) -> int:
         idx = (y * self.width + x) * 2
+        if idx >= len(self.block_data):
+            raise IndexError(f"Block coordinate ({x}, {y}) is out of bounds! Room size: ({self.width}, {self.height})")
         return self.block_data[idx] | self.block_data[idx + 1] << 8
 
     def set_block_value(self, value: int, x: int, y: int) -> None:


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/7e8b59b2-0fa9-4d1d-815e-9c304c122ca8)


While obviously more clunky to use than mage, it does allow for slightly more sophisticated plandos to be distributed later via rdv's rdvgame. (Aka no need to distribute a patch, and allows users to choose cosmetic settings)