### PR TITLE
Use context manager for BlockLayers

### DIFF
--- a/src/mars_patcher/item_patcher.py
+++ b/src/mars_patcher/item_patcher.py
@@ -69,9 +69,8 @@ class ItemPatcher:
             # overwrite clipdata
             room = RoomEntry(rom, min_loc.area, min_loc.room)
             val = HIDDEN_TANK_CLIP[tank_slot] if min_loc.hidden else TANK_CLIP[tank_slot]
-            room.load_clip()
-            room.set_clip_block(val, min_loc.block_x, min_loc.block_y)
-            room.write_clip()
+            with room.load_clip() as clip:
+                clip.set_block_value(val, min_loc.block_x, min_loc.block_y)
             # overwrite BG1 if not hidden
             if not min_loc.hidden:
                 # get tilemap
@@ -82,9 +81,8 @@ class ItemPatcher:
                 tile = TANK_TILE[tank_slot]
                 idx = next(i for i in range(16) if rom.read_8(addr + i * 8) == tile)
                 val = TANK_BG1_START + idx
-                room.load_bg1()
-                room.set_bg1_block(val, min_loc.block_x, min_loc.block_y)
-                room.write_bg1()
+                with room.load_bg1() as bg1:
+                    bg1.set_block_value(val, min_loc.block_x, min_loc.block_y)
 
             # write to minors array
             # Assembly has:

--- a/src/mars_patcher/level_edits.py
+++ b/src/mars_patcher/level_edits.py
@@ -13,21 +13,14 @@ def apply_level_edits(rom: Rom, edit_dict: dict) -> None:
             for layer, changes in layers.items():
                 if layer == "BG1":
                     load = r.load_bg1
-                    edit = r.set_bg1_block
-                    clean = r.write_bg1
                 elif layer == "BG2":
                     load = r.load_bg2
-                    edit = r.set_bg2_block
-                    clean = r.write_bg2
                 elif layer == "Clipdata":
                     load = r.load_clip
-                    edit = r.set_clip_block
-                    clean = r.write_clip
                 else:
                     ValueError("Unsupported Block Layer")
 
                 # Load layer, do every edit that's provided and write back.
-                load()
-                for change in changes:
-                    edit(change["Value"], change["X"], change["Y"])
-                clean()
+                with load() as layer:
+                    for change in changes:
+                        layer.set_block_value(change["Value"], change["X"], change["Y"])


### PR DESCRIPTION
This refactors the internal block layers to be context managers.
This allows them to be used in with statements to automatically clean up after themselves. Or manually, should you wish to manually clean up.