### PR TITLE
Direct on where to report alpha issues

### DIFF
--- a/src/mars_patcher/patcher.py
+++ b/src/mars_patcher/patcher.py
@@ -155,5 +155,7 @@ def patch(
     # Remove once in public beta
     print("------")
     print("Report all issues to the Randovania Discord Server (https://discord.gg/M23gCxj6fw)")
-    print("or alternatively this project's issue page (https://github.com/MetroidAdvRandomizerSystem/mars-patcher/issues)")
+    print(
+        "or alternatively this project's issue page (https://github.com/MetroidAdvRandomizerSystem/mars-patcher/issues)"
+    )
     print("Thank you")

--- a/src/mars_patcher/patcher.py
+++ b/src/mars_patcher/patcher.py
@@ -151,3 +151,9 @@ def patch(
 
     rom.save(output_path)
     status_update(-1, f"Output written to {output_path}")
+
+    # Remove once in public beta
+    print("------")
+    print("Report all issues to the Randovania Discord Server (https://discord.gg/M23gCxj6fw)")
+    print("or alternatively this project's issue page (https://github.com/MetroidAdvRandomizerSystem/mars-patcher/issues)")
+    print("Thank you")


### PR DESCRIPTION
Almost every case when someone discovered this project and set it up for themselves, it happened that they reported issues to the wrong place (or didn't report issues at all!). Be it either people's DMs or various non-related channels in the metroid fusion server.

To help with this, I'm (temporarily) printing now where to report issues, with RDV being prioritized first, because most issues frankly currently are RDVs fault (be it broken logic or missing extra data somewhere)