### PR TITLE
Adjust sector 5 minimap for ruined break room

### DIFF
--- a/src/mars_patcher/data/base_minimap_edits.json
+++ b/src/mars_patcher/data/base_minimap_edits.json
@@ -652,6 +652,21 @@
                 "Palette": 0
             },
             {
+                "Description": "Flooded Tower",
+                "X": 16,
+                "Y": 5,
+                "Tile": 97,
+                "Palette": 2
+            },
+            {
+                "Description": "Ruined Break Room",
+                "X": 17,
+                "Y": 5,
+                "Tile": 384,
+                "Palette": 2,
+                "HFlip": "True"
+            },
+            {
                 "Description": "Sector 4 Arrow",
                 "X": 22,
                 "Y": 8,


### PR DESCRIPTION
Adjusts the minimap tiles for Ruined Break Room and Flooded Tower to remove the implied connection through the destroyed wall.
<details><summary>Details</summary>
<p>
Before/After flooded tower visit
<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/c6ccab51-2b65-4bd9-844c-785e50698e52" />
<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/a5758862-d86e-4b89-96ad-d53ec7df936a" />

After Ruined Break Room visit
<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/9762aade-6b35-4df7-8b99-bb4bff98eb3e" />


</p>
</details> 

