### PR TITLE
Don't overwrite locked door room ID

### DIFF
--- a/src/mars_patcher/mf/door_locks.py
+++ b/src/mars_patcher/mf/door_locks.py
@@ -203,8 +203,6 @@ def set_door_locks(rom: Rom, data: list[MarsschemamfDoorlocksItem]) -> None:
             capped_slot, capless_slot = new_room_hatch_slots[area_room]
             if lock == HatchLock.LOCKED:
                 new_hatch_slot = orig_hatch_slot
-                # Mark door as deleted
-                rom.write_8(door_addr + 1, 0xFF)
             elif (lock is None and orig_has_cap) or (lock is not None and lock != HatchLock.OPEN):
                 # Has cap
                 new_hatch_slot = capped_slot


### PR DESCRIPTION
Fixes #173 

Setting the room ID to 0xFF just makes the door not show up in MAGE