### PR TITLE
[ZM] Fix gunship palette

### DIFF
--- a/src/mars_patcher/random_palettes.py
+++ b/src/mars_patcher/random_palettes.py
@@ -27,7 +27,10 @@ from mars_patcher.zm.auto_generated_types import (
     MarsschemazmPalettesColorspace,
     MarsschemazmPalettesRandomize,
 )
-from mars_patcher.zm.constants.game_data import statues_cutscene_palette_addr
+from mars_patcher.zm.constants.game_data import (
+    gunship_flashing_palette_addr,
+    statues_cutscene_palette_addr,
+)
 from mars_patcher.zm.constants.palettes import ENEMY_GROUPS_ZM, EXCLUDED_ENEMIES_ZM
 from mars_patcher.zm.constants.sprites import SpriteIdZM
 
@@ -288,12 +291,17 @@ class PaletteRandomizer:
         self.change_func(pal, change)
         pal.write(rom, pal_addr)
         self.randomized_pals.add(pal_addr)
-        if rom.is_mf() and sprite_id in {
-            SpriteIdMF.SAMUS_EATER_BUD,
-            SpriteIdMF.SAMUS_EATER,
-            SpriteIdMF.NETTORI,
-        }:
-            self.fix_nettori(change)
+        # Handle sprites with extra palettes
+        if rom.is_mf():
+            if sprite_id in {
+                SpriteIdMF.SAMUS_EATER_BUD,
+                SpriteIdMF.SAMUS_EATER,
+                SpriteIdMF.NETTORI,
+            }:
+                self.fix_nettori(change)
+        elif rom.is_zm():
+            if sprite_id == SpriteIdZM.GUNSHIP:
+                self.fix_zm_gunship(change)
 
     def get_sprite_addr(self, sprite_id: int) -> int:
         addr = gd.sprite_palette_ptrs(self.rom) + (sprite_id - 0x10) * 4
@@ -309,6 +317,14 @@ class PaletteRandomizer:
             pal = Palette(rows, self.rom, addr)
             self.change_func(pal, change)
             pal.write(self.rom, addr)
+
+    def fix_zm_gunship(self, change: ColorChange) -> None:
+        """The gunship has an extra palette stored separately, so it requires
+        the same color change."""
+        addr = gunship_flashing_palette_addr(self.rom)
+        pal = Palette(8, self.rom, addr)
+        self.change_func(pal, change)
+        pal.write(self.rom, addr)
 
     def fix_zm_palettes(self) -> None:
         if (

--- a/src/mars_patcher/zm/constants/game_data.py
+++ b/src/mars_patcher/zm/constants/game_data.py
@@ -70,5 +70,9 @@ def title_text_lines_addr(rom: Rom) -> int:
     return rom.read_ptr(ReservedPointersZM.TITLE_TEXT_LINES_PTR.value)
 
 
+def gunship_flashing_palette_addr(rom: Rom) -> int:
+    return rom.read_ptr(ReservedPointersZM.GUNSHIP_FLASHING_PALETTE_PTR.value)
+
+
 def statues_cutscene_palette_addr(rom: Rom) -> int:
     return rom.read_ptr(ReservedPointersZM.STATUES_CUTSCENE_PALETTE_PTR.value)

--- a/src/mars_patcher/zm/constants/reserved_space.py
+++ b/src/mars_patcher/zm/constants/reserved_space.py
@@ -47,6 +47,8 @@ class ReservedPointersZM(IntEnum):
     """Pointer to the list of pointers to the graphics for each sprite."""
     SPRITE_PALETTES_PTR = auto()
     """Pointer to the list of pointers to the palette for each sprite."""
+    GUNSHIP_FLASHING_PALETTE_PTR = auto()
+    """Pointer to an extra palette used by the gunship sprite."""
     SPRITESET_PTR = auto()
     """Pointer to the list of pointers to spriteset entries."""
     SAMUS_PALETTES_PTR = auto()

--- a/src/mars_patcher/zm/constants/sprites.py
+++ b/src/mars_patcher/zm/constants/sprites.py
@@ -32,6 +32,7 @@ class SpriteIdZM(IntEnum):
     GERUTA_GREEN = 0x37
     REO_GREEN_WINGS = 0x3F
     REO_PURPLE_WINGS = 0x40
+    GUNSHIP = 0x41
     CHARGE_BEAM = 0x44
     POWER_GRIP = 0x4C
     IMAGO_LARVA_RIGHT = 0x4D


### PR DESCRIPTION
Minor fix to include an extra palette for the gunship when randomizing palettes