### PR TITLE
Use snake_case for schema fields

### DIFF
--- a/src/mars_patcher/common_types.py
+++ b/src/mars_patcher/common_types.py
@@ -3,13 +3,17 @@ from typing import Annotated, TypeAlias
 import mars_patcher.mf.auto_generated_types as types_mf
 import mars_patcher.zm.auto_generated_types as types_zm
 
-TypeU8: TypeAlias = types_mf.Typeu8 | types_zm.TypeU8
+TypeU8: TypeAlias = types_mf.TypeU8 | types_zm.TypeU8
 
-AreaId: TypeAlias = types_mf.Areaid | types_zm.AreaId
+AreaId: TypeAlias = types_mf.AreaId | types_zm.AreaId
 RoomId: TypeAlias = TypeU8
 
 AreaRoomPair = tuple[AreaId, RoomId]
 
 MinimapId: TypeAlias = Annotated[int, "0 <= value < 10"]
 
-MusicMapping: TypeAlias = types_mf.Musicmapping | types_zm.Musicmapping
+RoomNamesItem: TypeAlias = types_mf.MarsschemamfRoomNamesItem | types_zm.MarsschemazmRoomNamesItem
+
+ItemMessagesType: TypeAlias = types_mf.ItemMessages | types_zm.ItemMessages
+
+MusicMapping: TypeAlias = types_mf.MusicMapping | types_zm.MusicMapping

--- a/src/mars_patcher/credits.py
+++ b/src/mars_patcher/credits.py
@@ -3,26 +3,17 @@ from mars_patcher.constants.credits import (
     TEXT_LINE_TYPES,
     LineType,
 )
-from mars_patcher.mf.auto_generated_types import MarsschemamfCreditstextItem
+from mars_patcher.mf.auto_generated_types import MarsschemamfCreditsTextItem
 from mars_patcher.rom import Rom
 from mars_patcher.zm.auto_generated_types import MarsschemazmCreditsTextItem
 
-CreditsTextItem = MarsschemamfCreditstextItem | MarsschemazmCreditsTextItem
+CreditsTextItem = MarsschemamfCreditsTextItem | MarsschemazmCreditsTextItem
 
 FULL_LINE_LEN = 36
 LINE_WIDTH = 30
 
 
 class CreditsLine:
-    # TODO: Use enum names in schema
-    LINE_TYPE_ENUMS = {
-        "Blank": LineType.BLANK,
-        "Blue": LineType.BLUE,
-        "Red": LineType.RED,
-        "White1": LineType.WHITE,
-        "White2": LineType.WHITE_BIG,
-    }
-
     def __init__(
         self,
         line_type: LineType,
@@ -37,10 +28,10 @@ class CreditsLine:
 
     @classmethod
     def from_json(cls, data: CreditsTextItem) -> "CreditsLine":
-        line_type = cls.LINE_TYPE_ENUMS[data["LineType"]]
-        blank_lines = data.get("BlankLines", 0)
-        text = data.get("Text")
-        centered = data.get("Centered", True)
+        line_type = LineType[data["line_type"]]
+        blank_lines = data.get("blank_lines", 0)
+        text = data.get("text")
+        centered = data.get("centered", True)
         return CreditsLine(line_type, blank_lines, text, centered)
 
 

--- a/src/mars_patcher/item_messages.py
+++ b/src/mars_patcher/item_messages.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import ClassVar
 
 from frozendict import frozendict
 from typing_extensions import Self
 
-from mars_patcher.mf.auto_generated_types import Itemmessages
+from mars_patcher.common_types import ItemMessagesType
 from mars_patcher.text import Language
 
 
@@ -21,33 +20,18 @@ class ItemMessages:
     centered: bool
     message_id: int
 
-    LANG_ENUMS: ClassVar[dict[str, Language]] = {
-        "JapaneseKanji": Language.JAPANESE_KANJI,
-        "JapaneseHiragana": Language.JAPANESE_HIRAGANA,
-        "English": Language.ENGLISH,
-        "German": Language.GERMAN,
-        "French": Language.FRENCH,
-        "Italian": Language.ITALIAN,
-        "Spanish": Language.SPANISH,
-    }
-
-    KIND_ENUMS: ClassVar[dict[str, ItemMessagesKind]] = {
-        "CustomMessage": ItemMessagesKind.CUSTOM_MESSAGE,
-        "MessageID": ItemMessagesKind.MESSAGE_ID,
-    }
-
     @classmethod
-    def from_json(cls, data: Itemmessages) -> Self:
+    def from_json(cls, data: ItemMessagesType) -> Self:
         item_messages: dict[Language, str] = {}
         centered = True
-        kind: ItemMessagesKind = cls.KIND_ENUMS[data["Kind"]]
+        kind = ItemMessagesKind[data["kind"]]
         message_id = 0
         if kind == ItemMessagesKind.CUSTOM_MESSAGE:
-            for lang_name, message in data["Languages"].items():
-                lang = cls.LANG_ENUMS[lang_name]
+            for lang_name, message in data["languages"].items():
+                lang = Language[lang_name]
                 item_messages[lang] = message
-            centered = data.get("Centered", True)
+            centered = data.get("centered", True)
         else:
-            message_id = data["MessageID"]
+            message_id = data["message_id"]
 
         return cls(kind, frozendict(item_messages), centered, message_id)

--- a/src/mars_patcher/level_edits.py
+++ b/src/mars_patcher/level_edits.py
@@ -11,11 +11,11 @@ def apply_level_edits(rom: Rom, edit_dict: dict) -> None:
 
             # Go through every layer
             for layer, changes in layers.items():
-                if layer == "BG1":
+                if layer == "bg1":
                     load = r.load_bg1
-                elif layer == "BG2":
+                elif layer == "bg2":
                     load = r.load_bg2
-                elif layer == "Clipdata":
+                elif layer == "clipdata":
                     load = r.load_clip
                 else:
                     raise ValueError("Unsupported Block Layer")
@@ -23,4 +23,4 @@ def apply_level_edits(rom: Rom, edit_dict: dict) -> None:
                 # Load layer, do every edit that's provided and write back.
                 with load() as layer:
                     for change in changes:
-                        layer.set_block_value(change["X"], change["Y"], change["Value"])
+                        layer.set_block_value(change["x"], change["y"], change["value"])

--- a/src/mars_patcher/mf/auto_generated_types.py
+++ b/src/mars_patcher/mf/auto_generated_types.py
@@ -9,12 +9,12 @@ import typing_extensions as typ
 
 # Definitions
 Seed: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 2147483647']
-Typeu4: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 15']
-Typeu5: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 31']
-Typeu8: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 255']
-Typeu10: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 1023']
-Areaid: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 6']
-Areaidkey = typ.Literal[
+TypeU4: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 15']
+TypeU5: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 31']
+TypeU8: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 255']
+TypeU10: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 1023']
+AreaId: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 6']
+AreaIdKey = typ.Literal[
     '0',
     '1',
     '2',
@@ -23,7 +23,7 @@ Areaidkey = typ.Literal[
     '5',
     '6'
 ]
-Minimapidkey = typ.Literal[
+MinimapIdKey = typ.Literal[
     '0',
     '1',
     '2',
@@ -36,158 +36,158 @@ Minimapidkey = typ.Literal[
     '9',
     '10'
 ]
-Sectorid: typ.TypeAlias = typ.Annotated[int, '1 <= value <= 6']
-Shortcutsectorlist: typ.TypeAlias = typ.Annotated[list[Sectorid], 'len() == 6']
-Huerotation: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 360']
-Validsources = typ.Literal[
-    'MainDeckData',
-    'Arachnus',
-    'ChargeCoreX',
-    'Level1',
-    'TroData',
-    'Zazabi',
-    'Serris',
-    'Level2',
-    'PyrData',
-    'MegaX',
-    'Level3',
-    'ArcData1',
-    'WideCoreX',
-    'ArcData2',
-    'Yakuza',
-    'Nettori',
-    'Nightmare',
-    'Level4',
-    'AqaData',
-    'WaveCoreX',
-    'Ridley',
-    'Boiler',
-    'Animals',
-    'AuxiliaryPower'
+SectorId: typ.TypeAlias = typ.Annotated[int, '1 <= value <= 6']
+ShortcutSectorList: typ.TypeAlias = typ.Annotated[list[SectorId], 'len() == 6']
+HueRotation: typ.TypeAlias = typ.Annotated[int, '0 <= value <= 360']
+ValidSources = typ.Literal[
+    'MAIN_DECK_DATA',
+    'ARACHNUS',
+    'CHARGE_CORE_X',
+    'LEVEL_1',
+    'TRO_DATA',
+    'ZAZABI',
+    'SERRIS',
+    'LEVEL_2',
+    'PYR_DATA',
+    'MEGA_X',
+    'LEVEL_3',
+    'ARC_DATA_1',
+    'WIDE_CORE_X',
+    'ARC_DATA_2',
+    'YAKUZA',
+    'NETTORI',
+    'NIGHTMARE',
+    'LEVEL_4',
+    'AQA_DATA',
+    'WAVE_CORE_X',
+    'RIDLEY',
+    'BOILER',
+    'ANIMALS',
+    'AUXILIARY_POWER'
 ]
-Validitems = typ.Literal[
-    'None',
-    'Level0',
-    'Missiles',
-    'MorphBall',
-    'ChargeBeam',
-    'Level1',
-    'Bombs',
-    'HiJump',
-    'SpeedBooster',
-    'Level2',
-    'SuperMissiles',
-    'VariaSuit',
-    'Level3',
-    'IceMissiles',
-    'WideBeam',
-    'PowerBombs',
-    'SpaceJump',
-    'PlasmaBeam',
-    'GravitySuit',
-    'Level4',
-    'DiffusionMissiles',
-    'WaveBeam',
-    'ScrewAttack',
-    'IceBeam',
-    'MissileTank',
-    'EnergyTank',
-    'PowerBombTank',
-    'IceTrap',
-    'InfantMetroid'
+ValidItems = typ.Literal[
+    'NONE',
+    'LEVEL_0',
+    'MISSILES',
+    'MORPH_BALL',
+    'CHARGE_BEAM',
+    'LEVEL_1',
+    'BOMBS',
+    'HI_JUMP',
+    'SPEED_BOOSTER',
+    'LEVEL_2',
+    'SUPER_MISSILES',
+    'VARIA_SUIT',
+    'LEVEL_3',
+    'ICE_MISSILES',
+    'WIDE_BEAM',
+    'POWER_BOMBS',
+    'SPACE_JUMP',
+    'PLASMA_BEAM',
+    'GRAVITY_SUIT',
+    'LEVEL_4',
+    'DIFFUSION_MISSILES',
+    'WAVE_BEAM',
+    'SCREW_ATTACK',
+    'ICE_BEAM',
+    'MISSILE_TANK',
+    'ENERGY_TANK',
+    'POWER_BOMB_TANK',
+    'ICE_TRAP',
+    'INFANT_METROID'
 ]
-Validitemsprites = typ.Literal[
-    'Empty',
-    'Missiles',
-    'Level0',
-    'MorphBall',
-    'ChargeBeam',
-    'Level1',
-    'Bombs',
-    'HiJump',
-    'SpeedBooster',
-    'Level2',
-    'SuperMissiles',
-    'VariaSuit',
-    'Level3',
-    'IceMissiles',
-    'WideBeam',
-    'PowerBombs',
-    'SpaceJump',
-    'PlasmaBeam',
-    'GravitySuit',
-    'Level4',
-    'DiffusionMissiles',
-    'WaveBeam',
-    'ScrewAttack',
-    'IceBeam',
-    'MissileTank',
-    'EnergyTank',
-    'PowerBombTank',
-    'Anonymous',
-    'ShinyMissileTank',
-    'ShinyPowerBombTank',
-    'InfantMetroid',
-    'SamusHead',
-    'WalljumpBoots',
-    'Randovania',
-    'ArchipelagoColor',
-    'ArchipelagoMonochrome'
+ValidItemSprites = typ.Literal[
+    'EMPTY',
+    'MISSILES',
+    'LEVEL_0',
+    'MORPH_BALL',
+    'CHARGE_BEAM',
+    'LEVEL_1',
+    'BOMBS',
+    'HI_JUMP',
+    'SPEED_BOOSTER',
+    'LEVEL_2',
+    'SUPER_MISSILES',
+    'VARIA_SUIT',
+    'LEVEL_3',
+    'ICE_MISSILES',
+    'WIDE_BEAM',
+    'POWER_BOMBS',
+    'SPACE_JUMP',
+    'PLASMA_BEAM',
+    'GRAVITY_SUIT',
+    'LEVEL_4',
+    'DIFFUSION_MISSILES',
+    'WAVE_BEAM',
+    'SCREW_ATTACK',
+    'ICE_BEAM',
+    'MISSILE_TANK',
+    'ENERGY_TANK',
+    'POWER_BOMB_TANK',
+    'ANONYMOUS',
+    'SHINY_MISSILE_TANK',
+    'SHINY_POWER_BOMB_TANK',
+    'INFANT_METROID',
+    'SAMUS_HEAD',
+    'WALLJUMP_BOOTS',
+    'RANDOVANIA',
+    'ARCHIPELAGO_COLOR',
+    'ARCHIPELAGO_MONOCHROME'
 ]
-Validabilities = typ.Literal[
-    'Missiles',
-    'MorphBall',
-    'ChargeBeam',
-    'Bombs',
-    'HiJump',
-    'SpeedBooster',
-    'SuperMissiles',
-    'VariaSuit',
-    'IceMissiles',
-    'WideBeam',
-    'PowerBombs',
-    'SpaceJump',
-    'PlasmaBeam',
-    'GravitySuit',
-    'DiffusionMissiles',
-    'WaveBeam',
-    'ScrewAttack',
-    'IceBeam'
+ValidAbilities = typ.Literal[
+    'MISSILES',
+    'MORPH_BALL',
+    'CHARGE_BEAM',
+    'BOMBS',
+    'HI_JUMP',
+    'SPEED_BOOSTER',
+    'SUPER_MISSILES',
+    'VARIA_SUIT',
+    'ICE_MISSILES',
+    'WIDE_BEAM',
+    'POWER_BOMBS',
+    'SPACE_JUMP',
+    'PLASMA_BEAM',
+    'GRAVITY_SUIT',
+    'DIFFUSION_MISSILES',
+    'WAVE_BEAM',
+    'SCREW_ATTACK',
+    'ICE_BEAM'
 ]
-Validelevatortops = typ.Literal[
-    'OperationsDeckTop',
-    'MainHubToSector1',
-    'MainHubToSector2',
-    'MainHubToSector3',
-    'MainHubToSector4',
-    'MainHubToSector5',
-    'MainHubToSector6',
-    'MainHubTop',
-    'HabitationDeckTop',
-    'Sector1ToRestrictedLab'
+ValidElevatorTops = typ.Literal[
+    'OPERATIONS_DECK_TOP',
+    'MAIN_HUB_TO_SECTOR_1',
+    'MAIN_HUB_TO_SECTOR_2',
+    'MAIN_HUB_TO_SECTOR_3',
+    'MAIN_HUB_TO_SECTOR_4',
+    'MAIN_HUB_TO_SECTOR_5',
+    'MAIN_HUB_TO_SECTOR_6',
+    'MAIN_HUB_TOP',
+    'HABITATION_DECK_TOP',
+    'SECTOR_1_TO_RESTRICTED_LAB'
 ]
-Validelevatorbottoms = typ.Literal[
-    'OperationsDeckBottom',
-    'MainHubBottom',
-    'RestrictedLabToSector1',
-    'HabitationDeckBottom',
-    'Sector1ToMainHub',
-    'Sector2ToMainHub',
-    'Sector3ToMainHub',
-    'Sector4ToMainHub',
-    'Sector5ToMainHub',
-    'Sector6ToMainHub'
+ValidElevatorBottoms = typ.Literal[
+    'OPERATIONS_DECK_BOTTOM',
+    'MAIN_HUB_BOTTOM',
+    'RESTRICTED_LAB_TO_SECTOR_1',
+    'HABITATION_DECK_BOTTOM',
+    'SECTOR_1_TO_MAIN_HUB',
+    'SECTOR_2_TO_MAIN_HUB',
+    'SECTOR_3_TO_MAIN_HUB',
+    'SECTOR_4_TO_MAIN_HUB',
+    'SECTOR_5_TO_MAIN_HUB',
+    'SECTOR_6_TO_MAIN_HUB'
 ]
-Validlanguages = typ.Literal[
-    'JapaneseKanji',
-    'JapaneseHiragana',
-    'English',
-    'German',
-    'French',
-    'Italian',
-    'Spanish'
+ValidLanguages = typ.Literal[
+    'JAPANESE_KANJI',
+    'JAPANESE_HIRAGANA',
+    'ENGLISH',
+    'GERMAN',
+    'FRENCH',
+    'ITALIAN',
+    'SPANISH'
 ]
-Validmusictracks = typ.Literal[
+ValidMusicTracks = typ.Literal[
     'UNUSED_1',
     'AFTER_EVENT',
     'SECTOR_1',
@@ -248,37 +248,37 @@ Validmusictracks = typ.Literal[
     'UNUSED_5E',
     'UNEASE'
 ]
-Musicmapping: typ.TypeAlias = dict[Validmusictracks, Validmusictracks]
-Messagelanguages: typ.TypeAlias = dict[Validlanguages, str]
+MusicMapping: typ.TypeAlias = dict[ValidMusicTracks, ValidMusicTracks]
+MessageLanguages: typ.TypeAlias = dict[ValidLanguages, str]
 
-class Itemmessages(typ.TypedDict, total=False):
-    Kind: typ.Required[Itemmessageskind]
-    Languages: Messagelanguages
-    Centered: bool = True
-    MessageID: typ.Annotated[int, '0 <= value <= 56']
+class ItemMessages(typ.TypedDict, total=False):
+    kind: typ.Required[ItemMessagesKind]
+    languages: MessageLanguages
+    centered: bool = True
+    message_id: typ.Annotated[int, '0 <= value <= 56']
     """The Message ID, will display one of the predefined messages in the ROM"""
 
-Itemmessageskind = typ.Literal[
-    'CustomMessage',
-    'MessageID'
+ItemMessagesKind = typ.Literal[
+    'CUSTOM_MESSAGE',
+    'MESSAGE_ID'
 ]
 Jingle = typ.Literal[
-    'Minor',
-    'Major'
+    'MINOR',
+    'MAJOR'
 ]
 
-class BlocklayerItem(typ.TypedDict, total=False):
-    X: Typeu8
+class BlockLayerItem(typ.TypedDict, total=False):
+    x: TypeU8
     """The X position in the room that should get edited."""
 
-    Y: Typeu8
+    y: TypeU8
     """The Y position in the room that should get edited."""
 
-    Value: Typeu10
+    value: TypeU10
     """The value that should be used to edit the room. For backgrounds, this is calculated via `((Row-1) * ColumnsInTileset) + (Column-1)`."""
 
-Blocklayer: typ.TypeAlias = typ.Annotated[list[BlocklayerItem], 'Unique items']
-Hintlocks = typ.Literal[
+BlockLayer: typ.TypeAlias = typ.Annotated[list[BlockLayerItem], 'Unique items']
+HintLocks = typ.Literal[
     'OPEN',
     'LOCKED',
     'GREY',
@@ -290,64 +290,64 @@ Hintlocks = typ.Literal[
 
 # Schema entries
 
-class MarsschemamfLocationsMajorlocationsItem(typ.TypedDict):
-    Source: Validsources
+class MarsschemamfLocationsMajorLocationsItem(typ.TypedDict):
+    source: ValidSources
     """Valid major locations."""
 
-    Item: Validitems
+    item: ValidItems
     """Valid items for shuffling."""
 
-    ItemMessages: typ.NotRequired[Itemmessages]
-    Jingle: Jingle
+    item_messages: typ.NotRequired[ItemMessages]
+    jingle: Jingle
 
-class MarsschemamfLocationsMinorlocationsItem(typ.TypedDict):
-    Area: Areaid
+class MarsschemamfLocationsMinorLocationsItem(typ.TypedDict):
+    area: AreaId
     """The area ID where this item is located."""
 
-    Room: Typeu8
+    room: TypeU8
     """The room ID where this item is located."""
 
-    BlockX: Typeu8
+    block_x: TypeU8
     """The X-coordinate in the room where this item is located."""
 
-    BlockY: Typeu8
+    block_y: TypeU8
     """The Y-coordinate in the room where this item is located."""
 
-    Item: Validitems
+    item: ValidItems
     """Valid items for shuffling."""
 
-    ItemSprite: typ.NotRequired[Validitemsprites]
+    item_sprite: typ.NotRequired[ValidItemSprites]
     """Valid graphics for minor location items."""
 
-    ItemMessages: typ.NotRequired[Itemmessages]
-    Jingle: Jingle
+    item_messages: typ.NotRequired[ItemMessages]
+    jingle: Jingle
 
 class MarsschemamfLocations(typ.TypedDict):
     """Specifies how the item locations in the game should be changed."""
 
-    MajorLocations: typ.Annotated[list[MarsschemamfLocationsMajorlocationsItem], 'len() == 23', 'Unique items']
+    major_locations: typ.Annotated[list[MarsschemamfLocationsMajorLocationsItem], 'len() == 23', 'Unique items']
     """Specifies how the major item locations should be changed. A major item location is a location where an item is obtained by defeating a boss or interacting with a device."""
 
-    MinorLocations: typ.Annotated[list[MarsschemamfLocationsMinorlocationsItem], 'len() == 103', 'Unique items']
+    minor_locations: typ.Annotated[list[MarsschemamfLocationsMinorLocationsItem], 'len() == 103', 'Unique items']
     """Specifies how the minor item locations should be changed. A minor item location is a location where an item is obtained by touching a tank block."""
 
 
-class MarsschemamfStartinglocation(typ.TypedDict):
+class MarsschemamfStartingLocation(typ.TypedDict):
     """The location the player should spawn at the start of the game."""
 
-    Area: Areaid
+    area: AreaId
     """The area ID of the starting location."""
 
-    Room: Typeu8
+    room: TypeU8
     """The room ID of the starting location."""
 
-    BlockX: Typeu8
+    block_x: TypeU8
     """The X-coordinate in the room where the player should spawn. If the room contains a save station, then this value will not be taken into consideration."""
 
-    BlockY: Typeu8
+    block_y: TypeU8
     """The Y-coordinate in the room where the player should spawn. If the room contains a save station, then this value will not be taken into consideration."""
 
-MarsschemamfStartingitemsSecuritylevelsItem = typ.Literal[
+MarsschemamfStartingItemsSecurityLevelsItem = typ.Literal[
     0,
     1,
     2,
@@ -355,286 +355,286 @@ MarsschemamfStartingitemsSecuritylevelsItem = typ.Literal[
     4
 ]
 
-class MarsschemamfStartingitems(typ.TypedDict, total=False):
-    Energy: typ.Annotated[int, '1 <= value <= 2099'] = 99
+class MarsschemamfStartingItems(typ.TypedDict, total=False):
+    energy: typ.Annotated[int, '1 <= value <= 2099'] = 99
     """How much energy the player should start with on a new save file."""
 
-    Missiles: typ.Annotated[int, '0 <= value <= 999'] = 10
+    missiles: typ.Annotated[int, '0 <= value <= 999'] = 10
     """How many missiles the player should start with on a new save file (the amount unlocked by collecting missile data)."""
 
-    PowerBombs: typ.Annotated[int, '0 <= value <= 99'] = 10
+    power_bombs: typ.Annotated[int, '0 <= value <= 99'] = 10
     """How many power bombs the player should start with on a new save file (the amount unlocked by collecting power bomb data)."""
 
-    Abilities: typ.Annotated[list[Validabilities], 'Unique items'] = []
+    abilities: typ.Annotated[list[ValidAbilities], 'Unique items'] = []
     """Which abilities the player should start with on a new save file."""
 
-    SecurityLevels: typ.Annotated[list[MarsschemamfStartingitemsSecuritylevelsItem], 'Unique items'] = [0]
+    security_levels: typ.Annotated[list[MarsschemamfStartingItemsSecurityLevelsItem], 'Unique items'] = [0]
     """Which security levels will be unlocked from the start."""
 
-    DownloadedMaps: typ.Annotated[list[Areaid], 'Unique items'] = []
+    downloaded_maps: typ.Annotated[list[AreaId], 'Unique items'] = []
     """Which area maps will be downloaded from the start."""
 
 
-class MarsschemamfTankincrements(typ.TypedDict):
+class MarsschemamfTankIncrements(typ.TypedDict):
     """How much ammo/health tanks provide when collected."""
 
-    MissileTank: typ.Annotated[int, '-1000 <= value <= 1000'] = 5
+    missile_tank: typ.Annotated[int, '-1000 <= value <= 1000'] = 5
     """How much ammo missile tanks provide when collected."""
 
-    EnergyTank: typ.Annotated[int, '-2100 <= value <= 2100'] = 100
+    energy_tank: typ.Annotated[int, '-2100 <= value <= 2100'] = 100
     """How much health energy tanks provide when collected."""
 
-    PowerBombTank: typ.Annotated[int, '-100 <= value <= 100'] = 2
+    power_bomb_tank: typ.Annotated[int, '-100 <= value <= 100'] = 2
     """How much ammo power bomb tanks provide when collected."""
 
-    MissileData: typ.NotRequired[typ.Annotated[int, '0 <= value <= 1000']] = 10
+    missile_data: typ.NotRequired[typ.Annotated[int, '0 <= value <= 1000']] = 10
     """How much ammo Missile Launcher Data provides when collected."""
 
-    PowerBombData: typ.NotRequired[typ.Annotated[int, '0 <= value <= 100']] = 10
+    power_bomb_data: typ.NotRequired[typ.Annotated[int, '0 <= value <= 100']] = 10
     """How much ammo Power Bomb Data provides when collected."""
 
 
-class MarsschemamfElevatorconnections(typ.TypedDict):
+class MarsschemamfElevatorConnections(typ.TypedDict):
     """Defines the elevator that each elevator connects to."""
 
-    ElevatorTops: typ.Annotated[dict[Validelevatortops, Validelevatorbottoms], 'len() >= 10']
+    elevator_tops: typ.Annotated[dict[ValidElevatorTops, ValidElevatorBottoms], 'len() >= 10']
     """Defines the bottom elevator that each top elevator connects to."""
 
-    ElevatorBottoms: typ.Annotated[dict[Validelevatorbottoms, Validelevatortops], 'len() >= 10']
+    elevator_bottoms: typ.Annotated[dict[ValidElevatorBottoms, ValidElevatorTops], 'len() >= 10']
     """Defines the top elevator that each bottom elevator connects to."""
 
 
-class MarsschemamfSectorshortcuts(typ.TypedDict):
+class MarsschemamfSectorShortcuts(typ.TypedDict):
     """Defines the sector that each sector shortcut connects to."""
 
-    LeftAreas: Shortcutsectorlist
+    left_areas: ShortcutSectorList
     """Destination areas on the left side of sectors."""
 
-    RightAreas: Shortcutsectorlist
+    right_areas: ShortcutSectorList
     """Destination areas on the right side of sectors"""
 
-MarsschemamfDoorlocksItemLocktype = typ.Literal[
-    'Open',
-    'Level0',
-    'Level1',
-    'Level2',
-    'Level3',
-    'Level4',
-    'Locked'
+MarsschemamfDoorLocksItemLockType = typ.Literal[
+    'OPEN',
+    'LEVEL_0',
+    'LEVEL_1',
+    'LEVEL_2',
+    'LEVEL_3',
+    'LEVEL_4',
+    'LOCKED'
 ]
 
-class MarsschemamfDoorlocksItem(typ.TypedDict):
-    Area: Areaid
+class MarsschemamfDoorLocksItem(typ.TypedDict):
+    area: AreaId
     """The area ID where this door is located."""
 
-    Door: Typeu8
+    door: TypeU8
     """The door ID of this door."""
 
-    LockType: MarsschemamfDoorlocksItemLocktype
+    lock_type: MarsschemamfDoorLocksItemLockType
     """The type of cover on the hatch."""
 
 MarsschemamfPalettesRandomizeKey = typ.Literal[
-    'Tilesets',
-    'Enemies',
-    'Samus',
-    'Beams'
+    'TILESETS',
+    'ENEMIES',
+    'SAMUS',
+    'BEAMS'
 ]
 
 @typ.final
 class MarsschemamfPalettesRandomize(typ.TypedDict, total=False):
     """The range to use for rotating palette hues."""
 
-    HueMin: Huerotation = None
+    hue_min: HueRotation = None
     """The minimum value to use for rotating palette hues. If not specified, the patcher will randomly generate one."""
 
-    HueMax: Huerotation = None
+    hue_max: HueRotation = None
     """The maximum value to use for rotating palette hues. If not specified, the patcher will randomly generate one."""
 
 
-MarsschemamfPalettesColorspace = typ.Literal[
+MarsschemamfPalettesColorSpace = typ.Literal[
     'HSV',
-    'Oklab'
+    'OKLAB'
 ]
 
 @typ.final
 class MarsschemamfPalettes(typ.TypedDict, total=False):
     """Properties for randomized in-game palettes."""
 
-    Seed: Seed = None
+    seed: Seed = None
     """A number used to initialize the random number generator for palettes. If not specified, the patcher will randomly generate one."""
 
-    Randomize: typ.Required[dict[MarsschemamfPalettesRandomizeKey, MarsschemamfPalettesRandomize]]
+    randomize: typ.Required[dict[MarsschemamfPalettesRandomizeKey, MarsschemamfPalettesRandomize]]
     """What kind of palettes should be randomized."""
 
-    ColorSpace: MarsschemamfPalettesColorspace = 'Oklab'
+    color_space: MarsschemamfPalettesColorSpace = 'OKLAB'
     """The color space to use for rotating palette hues."""
 
-    Symmetric: bool = True
+    symmetric: bool = True
     """Randomly rotates hues in the positive or negative direction true."""
 
 
-class MarsschemamfNavigationtextNavigationterminals(typ.TypedDict, total=False):
+class MarsschemamfNavigationTextNavigationTerminals(typ.TypedDict, total=False):
     """Assigns each navigation room a specific text."""
 
-    MainDeckWest: str
+    MAIN_DECK_WEST: str
     """Specifies what text should appear at the west Navigation Terminal in Main Deck."""
 
-    MainDeckEast: str
+    MAIN_DECK_EAST: str
     """Specifies what text should appear at the east Navigation Terminal in Main Deck."""
 
-    OperationsDeck: str
+    OPERATIONS_DECK: str
     """Specifies what text should appear at the Navigation Terminal in Operations Deck."""
 
-    Sector1Entrance: str
+    SECTOR_1_ENTRANCE: str
     """Specifies what text should appear at the Navigation Terminal in Sector 1."""
 
-    Sector2Entrance: str
+    SECTOR_2_ENTRANCE: str
     """Specifies what text should appear at the Navigation Terminal in Sector 2."""
 
-    Sector3Entrance: str
+    SECTOR_3_ENTRANCE: str
     """Specifies what text should appear at the Navigation Terminal in Sector 3."""
 
-    Sector4Entrance: str
+    SECTOR_4_ENTRANCE: str
     """Specifies what text should appear at the Navigation Terminal in Sector 4."""
 
-    Sector5Entrance: str
+    SECTOR_5_ENTRANCE: str
     """Specifies what text should appear at the Navigation Terminal in Sector 5."""
 
-    Sector6Entrance: str
+    SECTOR_6_ENTRANCE: str
     """Specifies what text should appear at the Navigation Terminal in Sector 6."""
 
-    AuxiliaryPower: str
+    AUXILIARY_POWER: str
     """Specifies what text should appear at the Navigation Terminal near the Auxiliary Power Station."""
 
-    RestrictedLabs: str
+    RESTRICTED_LABS: str
     """Specifies what text should appear at the Navigation Terminal in the Restricted Labs."""
 
 
-class MarsschemamfNavigationtextShiptext(typ.TypedDict, total=False):
+class MarsschemamfNavigationTextShipText(typ.TypedDict, total=False):
     """Assigns the ship specific text."""
 
-    InitialText: str
+    initial_text: str
     """Specifies what text should appear at the initial ship communication."""
 
-    ConfirmText: str
+    confirm_text: str
     """Specifies what text should appear at the ship after confirming 'No' on subsequent ship communications."""
 
 
 @typ.final
-class MarsschemamfNavigationtext(typ.TypedDict, total=False):
+class MarsschemamfNavigationText(typ.TypedDict, total=False):
     """Specifies text for a specific language."""
 
-    NavigationTerminals: MarsschemamfNavigationtextNavigationterminals
+    navigation_terminals: MarsschemamfNavigationTextNavigationTerminals
     """Assigns each navigation room a specific text."""
 
-    ShipText: MarsschemamfNavigationtextShiptext
+    ship_text: MarsschemamfNavigationTextShipText
     """Assigns the ship specific text."""
 
 
 
-class MarsschemamfTitletextItem(typ.TypedDict, total=False):
-    Text: typ.Annotated[str, '/^[ -~]{0,30}$/']
+class MarsschemamfTitleTextItem(typ.TypedDict, total=False):
+    text: typ.Annotated[str, '/^[ -~]{0,30}$/']
     """The ASCII text for this line"""
 
-    LineNum: typ.Annotated[int, '0 <= value <= 20']
-MarsschemamfCreditstextItemLinetype = typ.Literal[
-    'Blank',
-    'Blue',
-    'Red',
-    'White1',
-    'White2'
+    line_num: typ.Annotated[int, '0 <= value <= 20']
+MarsschemamfCreditsTextItemLineType = typ.Literal[
+    'BLANK',
+    'BLUE',
+    'RED',
+    'WHITE',
+    'WHITE_BIG'
 ]
 
-class MarsschemamfCreditstextItem(typ.TypedDict, total=False):
-    LineType: typ.Required[MarsschemamfCreditstextItemLinetype]
+class MarsschemamfCreditsTextItem(typ.TypedDict, total=False):
+    line_type: typ.Required[MarsschemamfCreditsTextItemLineType]
     """The color and line height of the text (or blank)."""
 
-    Text: typ.Annotated[str, '/^[ -~]{0,34}$/']
+    text: typ.Annotated[str, '/^[ -~]{0,34}$/']
     """The ASCII text for this line."""
 
-    BlankLines: Typeu8 = 0
+    blank_lines: TypeU8 = 0
     """Inserts the provided number of blank lines after the text line."""
 
-    Centered: bool = True
+    centered: bool = True
     """Centers the text horizontally when true."""
 
-MarsschemamfNavstationlocksKey = typ.Literal[
-    'MainDeckWest',
-    'MainDeckEast',
-    'OperationsDeck',
-    'RestrictedLabs',
-    'AuxiliaryPower',
-    'Sector1Entrance',
-    'Sector2Entrance',
-    'Sector3Entrance',
-    'Sector4Entrance',
-    'Sector5Entrance',
-    'Sector6Entrance'
+MarsschemamfNavStationLocksKey = typ.Literal[
+    'MAIN_DECK_WEST',
+    'MAIN_DECK_EAST',
+    'OPERATIONS_DECK',
+    'RESTRICTED_LABS',
+    'AUXILIARY_POWER',
+    'SECTOR_1_ENTRANCE',
+    'SECTOR_2_ENTRANCE',
+    'SECTOR_3_ENTRANCE',
+    'SECTOR_4_ENTRANCE',
+    'SECTOR_5_ENTRANCE',
+    'SECTOR_6_ENTRANCE'
 ]
 
 
-class MarsschemamfEnvironmentaldamage(typ.TypedDict):
-    Lava: Typeu8 = 20
+class MarsschemamfEnvironmentalDamage(typ.TypedDict):
+    lava: TypeU8 = 20
     """The amount of damage per second taken while submerged in lava."""
 
-    Acid: Typeu8 = 60
+    acid: TypeU8 = 60
     """The amount of damage per second taken while submerged in acid."""
 
-    Heat: Typeu8 = 6
+    heat: TypeU8 = 6
     """The amount of damage per second taken while in a heated environment."""
 
-    Cold: Typeu8 = 15
+    cold: TypeU8 = 15
     """The amount of damage per second taken while in a cold environment."""
 
-    Subzero: Typeu8 = 6
+    subzero: TypeU8 = 6
     """The amount of damage per second taken while in Sub-Zero Containment. Currently unused, will always use Cold."""
 
 
 @typ.final
-class MarsschemamfLeveledits(typ.TypedDict, total=False):
+class MarsschemamfLevelEdits(typ.TypedDict, total=False):
     """Specifies the Room ID."""
 
-    BG1: Blocklayer
+    bg1: BlockLayer
     """The BG1 layer that should be edited."""
 
-    BG2: Blocklayer
+    bg2: BlockLayer
     """The BG2 layer that should be edited."""
 
-    Clipdata: Blocklayer
+    clipdata: BlockLayer
     """The Clipdata layer that should be edited."""
 
 
 
 
-class MarsschemamfMinimapeditsItem(typ.TypedDict, total=False):
-    X: Typeu5
+class MarsschemamfMinimapEditsItem(typ.TypedDict, total=False):
+    x: TypeU5
     """The X position in the minimap that should get edited."""
 
-    Y: Typeu5
+    y: TypeU5
     """The Y position in the minimap that should get edited."""
 
-    Tile: Typeu10
+    tile: TypeU10
     """The tile value that should be used to edit the minimap."""
 
-    Palette: Typeu4
+    palette: TypeU4
     """The palette row to use for the tile."""
 
-    HFlip: bool = False
+    h_flip: bool = False
     """Whether the tile should be horizontally flipped or not."""
 
-    VFlip: bool = False
+    v_flip: bool = False
     """Whether the tile should be vertically flipped or not."""
 
 
 
-class MarsschemamfRoomnamesItem(typ.TypedDict):
-    Area: Areaid
+class MarsschemamfRoomNamesItem(typ.TypedDict):
+    area: AreaId
     """The area ID where this room is located."""
 
-    Room: Typeu8 = 3
+    room: TypeU8 = 3
     """The room ID."""
 
-    Name: typ.Annotated[str, 'len() <= 112']
+    name: typ.Annotated[str, 'len() <= 112']
     """Specifies what text should appear for this room. Two lines are available, with an absolute maximum of 56 characters per line, if all characters used are small. Text will auto-wrap if the next word doesn't fit on the line. If the text is too long, it will be truncated. Use 
  to force a line break. If not provided, will display 'Room name not provided'."""
 
@@ -646,93 +646,93 @@ class Marsschemamf(typ.TypedDict, total=False):
     A json schema describing the input for patching Metroid Fusion via mars_patcher.
     """
 
-    SeedHash: typ.Required[typ.Annotated[str, '/^[0-9A-Z]{8}$/']]
+    seed_hash: typ.Required[typ.Annotated[str, '/^[0-9A-Z]{8}$/']]
     """A seed hash that will be displayed on the file select screen."""
 
-    MusicReplacement: Musicmapping
+    music_replacement: MusicMapping
     """Shuffles the in-game music."""
 
-    Locations: typ.Required[MarsschemamfLocations]
+    locations: typ.Required[MarsschemamfLocations]
     """Specifies how the item locations in the game should be changed."""
 
-    RequiredMetroidCount: typ.Required[typ.Annotated[int, '0 <= value <= 20']]
+    required_metroid_count: typ.Required[typ.Annotated[int, '0 <= value <= 20']]
     """The number of infant Metroids that must be collected to beat the game."""
 
-    StartingLocation: MarsschemamfStartinglocation
+    starting_location: MarsschemamfStartingLocation
     """The location the player should spawn at the start of the game."""
 
-    StartingItems: MarsschemamfStartingitems = None
-    TankIncrements: MarsschemamfTankincrements = None
+    starting_items: MarsschemamfStartingItems = None
+    tank_increments: MarsschemamfTankIncrements = None
     """How much ammo/health tanks provide when collected."""
 
-    ElevatorConnections: MarsschemamfElevatorconnections
+    elevator_connections: MarsschemamfElevatorConnections
     """Defines the elevator that each elevator connects to."""
 
-    SectorShortcuts: MarsschemamfSectorshortcuts
+    sector_shortcuts: MarsschemamfSectorShortcuts
     """Defines the sector that each sector shortcut connects to."""
 
-    DoorLocks: list[MarsschemamfDoorlocksItem]
+    door_locks: list[MarsschemamfDoorLocksItem]
     """List of all lockable doors and their lock type."""
 
-    Palettes: MarsschemamfPalettes = None
+    palettes: MarsschemamfPalettes = None
     """Properties for randomized in-game palettes."""
 
-    NavigationText: dict[Validlanguages, MarsschemamfNavigationtext] = None
+    navigation_text: dict[ValidLanguages, MarsschemamfNavigationText] = None
     """Specifies text to be displayed at navigation rooms and the ship."""
 
-    TitleText: list[MarsschemamfTitletextItem] = None
+    title_text: list[MarsschemamfTitleTextItem] = None
     """Lines of ASCII text to write to the title screen."""
 
-    CreditsText: list[MarsschemamfCreditstextItem]
+    credits_text: list[MarsschemamfCreditsTextItem]
     """Lines of text to insert into the credits."""
 
-    NavStationLocks: dict[MarsschemamfNavstationlocksKey, Hintlocks]
+    nav_station_locks: dict[MarsschemamfNavStationLocksKey, HintLocks]
     """Sets the required Security Levels for accessing Navigation Terminals."""
 
-    DisableDemos: bool = False
+    disable_demos: bool = False
     """Disables title screen demos when true."""
 
-    InstantUnmorph: bool = False
+    instant_unmorph: bool = False
     """When true, enables instant unmorphing via the SELECT button."""
 
-    NerfGerons: bool = False
+    nerf_gerons: bool = False
     """When true, changes the Geron weaknesses to only be weak to their 'intended' values."""
 
-    UseAlternativeHudHealthLayout: bool = False
+    use_alternative_hud_health_layout: bool = False
     """When true, changes the HUD health layout to display 'currentHP/totalHP'."""
 
-    SkipDoorTransitions: bool = False
+    skip_door_transitions: bool = False
     """Makes all door transitions instant when true."""
 
-    StereoDefault: bool = True
+    stereo_default: bool = True
     """Forces stereo sound by default when true."""
 
-    DisableMusic: bool = False
+    disable_music: bool = False
     """Disables all music tracks when true."""
 
-    DisableSoundEffects: bool = False
+    disable_sound_effects: bool = False
     """Disables all sound effects when true."""
 
-    EnvironmentalDamage: MarsschemamfEnvironmentaldamage
-    MissileLimit: Typeu8 = 3
+    environmental_damage: MarsschemamfEnvironmentalDamage
+    missile_limit: TypeU8 = 3
     """Changes how many missiles can be on-screen at a time. The vanilla game has it set to 2, the randomizer changes it to 3 by default. Zero Mission uses 4."""
 
-    UnexploredMap: bool = False
+    unexplored_map: bool = False
     """When enabled, starts you with a map where all unexplored items and non-visited tiles have a gray background. This is different from the downloaded map stations where there, the full tile is gray."""
 
-    LevelEdits: dict[Areaidkey, dict[str, MarsschemamfLeveledits]]
+    level_edits: dict[AreaIdKey, dict[str, MarsschemamfLevelEdits]]
     """Specifies room edits that should be done. These will be applied last."""
 
-    MinimapEdits: dict[Minimapidkey, list[MarsschemamfMinimapeditsItem]]
+    minimap_edits: dict[MinimapIdKey, list[MarsschemamfMinimapEditsItem]]
     """Specifies minimap edits that should be done."""
 
-    HideDoorsOnMinimap: bool = False
+    hide_doors_on_minimap: bool = False
     """When enabled, hides doors on the minimap. This is automatically enabled when the 'DoorLocks' field is provided."""
 
-    RoomNames: typ.Annotated[list[MarsschemamfRoomnamesItem], 'Unique items']
+    room_names: typ.Annotated[list[MarsschemamfRoomNamesItem], 'Unique items']
     """Specifies a name to be displayed when the A Button is pressed on the pause menu."""
 
-    RevealHiddenTiles: bool = False
+    reveal_hidden_tiles: bool = False
     """When enabled, reveals normally hidden blocks that are breakable by upgrades. Hidden pickup tanks are not revealed regardless of this setting."""
 
 MarsSchemaMF: typ.TypeAlias = Marsschemamf

--- a/src/mars_patcher/mf/connections.py
+++ b/src/mars_patcher/mf/connections.py
@@ -2,10 +2,10 @@ from collections.abc import Sequence
 
 import mars_patcher.constants.game_data as gd
 from mars_patcher.mf.auto_generated_types import (
-    MarsschemamfElevatorconnections,
-    MarsschemamfSectorshortcuts,
-    Validelevatorbottoms,
-    Validelevatortops,
+    MarsschemamfElevatorConnections,
+    MarsschemamfSectorShortcuts,
+    ValidElevatorBottoms,
+    ValidElevatorTops,
 )
 from mars_patcher.mf.constants.main_hub_numbers import (
     MAIN_HUB_CENTER_ROOM,
@@ -27,29 +27,29 @@ from mars_patcher.tilemap import Tilemap
 
 # Area ID, Room ID, Is area connection
 ELEVATOR_TOPS = {
-    "OperationsDeckTop": (0, 0x1A, False),
-    "MainHubToSector1": (0, 0x43, True),
-    "MainHubToSector2": (0, 0x44, True),
-    "MainHubToSector3": (0, 0x45, True),
-    "MainHubToSector4": (0, 0x46, True),
-    "MainHubToSector5": (0, 0x47, True),
-    "MainHubToSector6": (0, 0x48, True),
-    "MainHubTop": (0, 0x5E, False),
-    "HabitationDeckTop": (0, 0xB2, False),
-    "Sector1ToRestrictedLab": (1, 0x41, True),
+    "OPERATIONS_DECK_TOP": (0, 0x1A, False),
+    "MAIN_HUB_TO_SECTOR_1": (0, 0x43, True),
+    "MAIN_HUB_TO_SECTOR_2": (0, 0x44, True),
+    "MAIN_HUB_TO_SECTOR_3": (0, 0x45, True),
+    "MAIN_HUB_TO_SECTOR_4": (0, 0x46, True),
+    "MAIN_HUB_TO_SECTOR_5": (0, 0x47, True),
+    "MAIN_HUB_TO_SECTOR_6": (0, 0x48, True),
+    "MAIN_HUB_TOP": (0, 0x5E, False),
+    "HABITATION_DECK_TOP": (0, 0xB2, False),
+    "SECTOR_1_TO_RESTRICTED_LAB": (1, 0x41, True),
 }
 
 ELEVATOR_BOTTOMS = {
-    "OperationsDeckBottom": (0, 0x19, False),
-    "MainHubBottom": (0, 0x32, False),
-    "RestrictedLabToSector1": (0, 0x9A, True),
-    "HabitationDeckBottom": (0, 0xB1, False),
-    "Sector1ToMainHub": (1, 0x00, True),
-    "Sector2ToMainHub": (2, 0x00, True),
-    "Sector3ToMainHub": (3, 0x00, True),
-    "Sector4ToMainHub": (4, 0x00, True),
-    "Sector5ToMainHub": (5, 0x00, True),
-    "Sector6ToMainHub": (6, 0x00, True),
+    "OPERATIONS_DECK_BOTTOM": (0, 0x19, False),
+    "MAIN_HUB_BOTTOM": (0, 0x32, False),
+    "RESTRICTED_LAB_TO_SECTOR_1": (0, 0x9A, True),
+    "HABITATION_DECK_BOTTOM": (0, 0xB1, False),
+    "SECTOR_1_TO_MAIN_HUB": (1, 0x00, True),
+    "SECTOR_2_TO_MAIN_HUB": (2, 0x00, True),
+    "SECTOR_3_TO_MAIN_HUB": (3, 0x00, True),
+    "SECTOR_4_TO_MAIN_HUB": (4, 0x00, True),
+    "SECTOR_5_TO_MAIN_HUB": (5, 0x00, True),
+    "SECTOR_6_TO_MAIN_HUB": (6, 0x00, True),
 }
 
 # (Area ID, Dest area): Door ID
@@ -74,7 +74,7 @@ class Connections:
         self.area_conns_addr = gd.area_connections(rom)
         self.area_conns_count = gd.area_connections_count(rom)
 
-    def set_elevator_connections(self, data: MarsschemamfElevatorconnections) -> None:
+    def set_elevator_connections(self, data: MarsschemamfElevatorConnections) -> None:
         # Reserve space for 8 more area connections and repoint
         size = self.area_conns_count * 3
         ac_data = self.rom.read_bytes(self.area_conns_addr, size)
@@ -85,10 +85,10 @@ class Connections:
         )
 
         # Connect tops to bottoms
-        pairs_top = data["ElevatorTops"]
+        pairs_top = data["elevator_tops"]
         self.connect_elevators(ELEVATOR_TOPS, ELEVATOR_BOTTOMS, pairs_top)
         # Connect bottoms to tops
-        pairs_bottom = data["ElevatorBottoms"]
+        pairs_bottom = data["elevator_bottoms"]
         self.connect_elevators(ELEVATOR_BOTTOMS, ELEVATOR_TOPS, pairs_bottom)
         if self.rom.game == Game.MF:
             # Update area number tiles in main hub rooms
@@ -96,10 +96,10 @@ class Connections:
             # Remove area numbers from Main Deck minimap
             self.remove_main_deck_minimap_area_nums()
 
-    def set_shortcut_connections(self, data: MarsschemamfSectorshortcuts) -> None:
-        for i, dst_area in enumerate(data["LeftAreas"]):
+    def set_shortcut_connections(self, data: MarsschemamfSectorShortcuts) -> None:
+        for i, dst_area in enumerate(data["left_areas"]):
             self.connect_shortcuts(i + 1, dst_area, True)
-        for i, dst_area in enumerate(data["RightAreas"]):
+        for i, dst_area in enumerate(data["right_areas"]):
             self.connect_shortcuts(i + 1, dst_area, False)
 
     def connect_shortcuts(self, area: int, dst_area: int, left: bool) -> None:
@@ -136,8 +136,8 @@ class Connections:
         self,
         src_dict: dict,
         dst_dict: dict,
-        pairs: dict[Validelevatortops, Validelevatorbottoms]
-        | dict[Validelevatorbottoms, Validelevatortops],
+        pairs: dict[ValidElevatorTops, ValidElevatorBottoms]
+        | dict[ValidElevatorBottoms, ValidElevatorTops],
     ) -> None:
         for src_name, dst_name in pairs.items():
             src_area, src_door, in_list = src_dict[src_name]

--- a/src/mars_patcher/mf/constants/items.py
+++ b/src/mars_patcher/mf/constants/items.py
@@ -26,7 +26,7 @@ class MajorSource(IntEnum):
     RIDLEY = auto()
     BOILER = auto()
     ANIMALS = auto()
-    AUXILIARYPOWER = auto()
+    AUXILIARY_POWER = auto()
 
 
 class ItemType(IntEnum):
@@ -107,19 +107,19 @@ class ItemSprite(IntEnum):
     ARCHIPELAGO_MONOCHROME = auto()
 
 
-KEY_MAJOR_LOCS: Final = "MajorLocations"
-KEY_MINOR_LOCS: Final = "MinorLocations"
-KEY_AREA: Final = "Area"
-KEY_ROOM: Final = "Room"
-KEY_SOURCE: Final = "Source"
-KEY_BLOCK_X: Final = "BlockX"
-KEY_BLOCK_Y: Final = "BlockY"
-KEY_HIDDEN: Final = "Hidden"
-KEY_ORIGINAL: Final = "Original"
-KEY_ITEM: Final = "Item"
-KEY_ITEM_SPRITE: Final = "ItemSprite"
-KEY_ITEM_MESSAGES: Final = "ItemMessages"
-KEY_ITEM_JINGLE: Final = "Jingle"
+KEY_MAJOR_LOCS: Final = "major_locations"
+KEY_MINOR_LOCS: Final = "minor_locations"
+KEY_AREA: Final = "area"
+KEY_ROOM: Final = "room"
+KEY_SOURCE: Final = "source"
+KEY_BLOCK_X: Final = "block_x"
+KEY_BLOCK_Y: Final = "block_y"
+KEY_HIDDEN: Final = "hidden"
+KEY_ORIGINAL: Final = "original"
+KEY_ITEM: Final = "item"
+KEY_ITEM_SPRITE: Final = "item_sprite"
+KEY_ITEM_MESSAGES: Final = "item_messages"
+KEY_ITEM_JINGLE: Final = "jingle"
 
 
 class ItemJingle(IntEnum):
@@ -127,125 +127,22 @@ class ItemJingle(IntEnum):
     MAJOR = auto()
 
 
-JINGLE_ENUMS = {"Minor": ItemJingle.MINOR, "Major": ItemJingle.MAJOR}
-
-SOURCE_ENUMS = {
-    "MainDeckData": MajorSource.MAIN_DECK_DATA,
-    "Arachnus": MajorSource.ARACHNUS,
-    "ChargeCoreX": MajorSource.CHARGE_CORE_X,
-    "Level1": MajorSource.LEVEL_1,
-    "TroData": MajorSource.TRO_DATA,
-    "Zazabi": MajorSource.ZAZABI,
-    "Serris": MajorSource.SERRIS,
-    "Level2": MajorSource.LEVEL_2,
-    "PyrData": MajorSource.PYR_DATA,
-    "MegaX": MajorSource.MEGA_X,
-    "Level3": MajorSource.LEVEL_3,
-    "ArcData1": MajorSource.ARC_DATA_1,
-    "WideCoreX": MajorSource.WIDE_CORE_X,
-    "ArcData2": MajorSource.ARC_DATA_2,
-    "Yakuza": MajorSource.YAKUZA,
-    "Nettori": MajorSource.NETTORI,
-    "Nightmare": MajorSource.NIGHTMARE,
-    "Level4": MajorSource.LEVEL_4,
-    "AqaData": MajorSource.AQA_DATA,
-    "WaveCoreX": MajorSource.WAVE_CORE_X,
-    "Ridley": MajorSource.RIDLEY,
-    "Boiler": MajorSource.BOILER,
-    "Animals": MajorSource.ANIMALS,
-    "AuxiliaryPower": MajorSource.AUXILIARYPOWER,
-}
-
-ITEM_ENUMS = {
-    "Undefined": ItemType.UNDEFINED,
-    "None": ItemType.NONE,
-    "Level0": ItemType.LEVEL_0,
-    "Missiles": ItemType.MISSILES,
-    "MorphBall": ItemType.MORPH_BALL,
-    "ChargeBeam": ItemType.CHARGE_BEAM,
-    "Level1": ItemType.LEVEL_1,
-    "Bombs": ItemType.BOMBS,
-    "HiJump": ItemType.HI_JUMP,
-    "SpeedBooster": ItemType.SPEED_BOOSTER,
-    "Level2": ItemType.LEVEL_2,
-    "SuperMissiles": ItemType.SUPER_MISSILES,
-    "VariaSuit": ItemType.VARIA_SUIT,
-    "Level3": ItemType.LEVEL_3,
-    "IceMissiles": ItemType.ICE_MISSILES,
-    "WideBeam": ItemType.WIDE_BEAM,
-    "PowerBombs": ItemType.POWER_BOMBS,
-    "SpaceJump": ItemType.SPACE_JUMP,
-    "PlasmaBeam": ItemType.PLASMA_BEAM,
-    "GravitySuit": ItemType.GRAVITY_SUIT,
-    "Level4": ItemType.LEVEL_4,
-    "DiffusionMissiles": ItemType.DIFFUSION_MISSILES,
-    "WaveBeam": ItemType.WAVE_BEAM,
-    "ScrewAttack": ItemType.SCREW_ATTACK,
-    "IceBeam": ItemType.ICE_BEAM,
-    "MissileTank": ItemType.MISSILE_TANK,
-    "EnergyTank": ItemType.ENERGY_TANK,
-    "PowerBombTank": ItemType.POWER_BOMB_TANK,
-    "IceTrap": ItemType.ICE_TRAP,
-    "InfantMetroid": ItemType.INFANT_METROID,
-}
-
-ITEM_SPRITE_ENUMS = {
-    "Empty": ItemSprite.EMPTY,
-    "Level0": ItemSprite.LEVEL_0,
-    "Missiles": ItemSprite.MISSILES,
-    "MorphBall": ItemSprite.MORPH_BALL,
-    "ChargeBeam": ItemSprite.CHARGE_BEAM,
-    "Level1": ItemSprite.LEVEL_1,
-    "Bombs": ItemSprite.BOMBS,
-    "HiJump": ItemSprite.HI_JUMP,
-    "SpeedBooster": ItemSprite.SPEED_BOOSTER,
-    "Level2": ItemSprite.LEVEL_2,
-    "SuperMissiles": ItemSprite.SUPER_MISSILES,
-    "VariaSuit": ItemSprite.VARIA_SUIT,
-    "Level3": ItemSprite.LEVEL_3,
-    "IceMissiles": ItemSprite.ICE_MISSILES,
-    "WideBeam": ItemSprite.WIDE_BEAM,
-    "PowerBombs": ItemSprite.POWER_BOMBS,
-    "SpaceJump": ItemSprite.SPACE_JUMP,
-    "PlasmaBeam": ItemSprite.PLASMA_BEAM,
-    "GravitySuit": ItemSprite.GRAVITY_SUIT,
-    "Level4": ItemSprite.LEVEL_4,
-    "DiffusionMissiles": ItemSprite.DIFFUSION_MISSILES,
-    "WaveBeam": ItemSprite.WAVE_BEAM,
-    "ScrewAttack": ItemSprite.SCREW_ATTACK,
-    "IceBeam": ItemSprite.ICE_BEAM,
-    "MissileTank": ItemSprite.MISSILE_TANK,
-    "EnergyTank": ItemSprite.ENERGY_TANK,
-    "PowerBombTank": ItemSprite.POWER_BOMB_TANK,
-    "Anonymous": ItemSprite.ANONYMOUS,
-    "ShinyMissileTank": ItemSprite.SHINY_MISSILE_TANK,
-    "ShinyPowerBombTank": ItemSprite.SHINY_POWER_BOMB_TANK,
-    "InfantMetroid": ItemSprite.INFANT_METROID,
-    "SamusHead": ItemSprite.SAMUS_HEAD,
-    "WalljumpBoots": ItemSprite.WALLJUMP_BOOTS,
-    "Randovania": ItemSprite.RANDOVANIA,
-    "ArchipelagoColor": ItemSprite.ARCHIPELAGO_COLOR,
-    "ArchipelagoMonochrome": ItemSprite.ARCHIPELAGO_MONOCHROME,
-}
-
-
-# TODO: Consider creating "game_enums.py"
-BEAM_FLAGS = {"ChargeBeam": 1, "WideBeam": 2, "PlasmaBeam": 4, "WaveBeam": 8, "IceBeam": 0x10}
+BEAM_FLAGS = {"CHARGE_BEAM": 1, "WIDE_BEAM": 2, "PLASMA_BEAM": 4, "WAVE_BEAM": 8, "ICE_BEAM": 0x10}
 MISSILE_BOMB_FLAGS = {
-    "Missiles": 1,
-    "SuperMissiles": 2,
-    "IceMissiles": 4,
-    "DiffusionMissiles": 8,
-    "Bombs": 0x10,
-    "PowerBombs": 0x20,
+    "MISSILES": 1,
+    "SUPER_MISSILES": 2,
+    "ICE_MISSILES": 4,
+    "DIFFUSION_MISSILES": 8,
+    "BOMBS": 0x10,
+    "POWER_BOMBS": 0x20,
 }
 SUIT_MISC_FLAGS = {
-    "HiJump": 1,
-    "SpeedBooster": 2,
-    "SpaceJump": 4,
-    "ScrewAttack": 8,
-    "VariaSuit": 0x10,
-    "GravitySuit": 0x20,
-    "MorphBall": 0x40,
-    "SaxSuit": 0x80,
+    "HI_JUMP": 1,
+    "SPEED_BOOSTER": 2,
+    "SPACE_JUMP": 4,
+    "SCREW_ATTACK": 8,
+    "VARIA_SUIT": 0x10,
+    "GRAVITY_SUIT": 0x20,
+    "MORPH_BALL": 0x40,
+    "SA_X_SUIT": 0x80,
 }

--- a/src/mars_patcher/mf/credits.py
+++ b/src/mars_patcher/mf/credits.py
@@ -1,5 +1,5 @@
 from mars_patcher.credits import CreditsLine, CreditsWriter
-from mars_patcher.mf.auto_generated_types import MarsschemamfCreditstextItem
+from mars_patcher.mf.auto_generated_types import MarsschemamfCreditsTextItem
 from mars_patcher.mf.constants.credits_lines import (
     FUSION_STAFF_LINES,
     MARS_CREDITS,
@@ -11,7 +11,7 @@ CREDITS_ADDR = 0x74B0B0
 CREDITS_LEN = 0x2B98
 
 
-def write_credits(rom: Rom, data: list[MarsschemamfCreditstextItem]) -> None:
+def write_credits(rom: Rom, data: list[MarsschemamfCreditsTextItem]) -> None:
     writer = CreditsWriter(rom)
 
     # Write MARS credits

--- a/src/mars_patcher/mf/data/base_minimap_edits.json
+++ b/src/mars_patcher/mf/data/base_minimap_edits.json
@@ -1,709 +1,709 @@
 {
     "0": [
         {
-            "Description": "Sector 1 Marker from Restricted Lab",
-            "X": 7,
-            "Y": 18,
-            "Tile": 172,
-            "Palette": 0
+            "description": "Sector 1 Marker from Restricted Lab",
+            "x": 7,
+            "y": 18,
+            "tile": 172,
+            "palette": 0
         },
         {
-            "Description": "Sector 1 Elevator Lines from Restricted Lab",
-            "X": 7,
-            "Y": 19,
-            "Tile": 169,
-            "Palette": 2
+            "description": "Sector 1 Elevator Lines from Restricted Lab",
+            "x": 7,
+            "y": 19,
+            "tile": 169,
+            "palette": 2
         },
         {
-            "Description": "Add Item to Quarantine Bay",
-            "X": 8,
-            "Y": 9,
-            "Tile": 386,
-            "Palette": 0
+            "description": "Add Item to Quarantine Bay",
+            "x": 8,
+            "y": 9,
+            "tile": 386,
+            "palette": 0
         },
         {
-            "Description": "Add Item to Subzero Containment",
-            "X": 9,
-            "Y": 10,
-            "Tile": 386,
-            "Palette": 0
+            "description": "Add Item to Subzero Containment",
+            "x": 9,
+            "y": 10,
+            "tile": 386,
+            "palette": 0
         },
         {
-            "Description": "Add L3 Locks to Subzero Containment",
-            "X": 10,
-            "Y": 10,
-            "Tile": 84,
-            "Palette": 0,
+            "description": "Add L3 Locks to Subzero Containment",
+            "x": 10,
+            "y": 10,
+            "tile": 84,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Sector 6 Arrow from Restricted Lab",
-            "X": 10,
-            "Y": 23,
-            "Tile": 170,
-            "Palette": 0,
+            "description": "Sector 6 Arrow from Restricted Lab",
+            "x": 10,
+            "y": 23,
+            "tile": 170,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Sector 6 Marker from Restricted Lab",
-            "X": 11,
-            "Y": 23,
-            "Tile": 177,
-            "Palette": 0
+            "description": "Sector 6 Marker from Restricted Lab",
+            "x": 11,
+            "y": 23,
+            "tile": 177,
+            "palette": 0
         },
         {
-            "Description": "Add L3 Locks to Dark Stairwell",
-            "X": 11,
-            "Y": 10,
-            "Tile": 117,
-            "Palette": 0,
+            "description": "Add L3 Locks to Dark Stairwell",
+            "x": 11,
+            "y": 10,
+            "tile": 117,
+            "palette": 0,
             "VFlip": "True"
         },
         {
-            "Description": "Sector 2 Marker from Central Reactor Core",
-            "X": 14,
-            "Y": 16,
-            "Tile": 173,
-            "Palette": 0
+            "description": "Sector 2 Marker from Central Reactor Core",
+            "x": 14,
+            "y": 16,
+            "tile": 173,
+            "palette": 0
         },
         {
-            "Description": "Connector Arrow to Sector 2 from Central Reactor Core",
-            "X": 15,
-            "Y": 16,
-            "Tile": 164,
-            "Palette": 0,
+            "description": "Connector Arrow to Sector 2 from Central Reactor Core",
+            "x": 15,
+            "y": 16,
+            "tile": 164,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Change Operations Deck Door from L4 to L0",
-            "X": 16,
-            "Y": 0,
-            "Tile": 299,
-            "Palette": 0,
+            "description": "Change Operations Deck Door from L4 to L0",
+            "x": 16,
+            "y": 0,
+            "tile": 299,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Change Operations Deck Door from L4 to L0",
-            "X": 17,
-            "Y": 0,
-            "Tile": 293,
-            "Palette": 0
+            "description": "Change Operations Deck Door from L4 to L0",
+            "x": 17,
+            "y": 0,
+            "tile": 293,
+            "palette": 0
         },
         {
-            "Description": "Change Hidden Concourse Recharge Into Normal",
-            "X": 17,
-            "Y": 7,
-            "Tile": 344,
-            "Palette": 0
+            "description": "Change Hidden Concourse Recharge Into Normal",
+            "x": 17,
+            "y": 7,
+            "tile": 344,
+            "palette": 0
         },
         {
-            "Description": "Add Animals Event Marker",
-            "X": 9,
-            "Y": 2,
-            "Tile": 369,
-            "Palette": 0
+            "description": "Add Animals Event Marker",
+            "x": 9,
+            "y": 2,
+            "tile": 369,
+            "palette": 0
         },
         {
-            "Description": "Remove Left Of Main Elevator Vents To Cold Storage",
-            "X": 7,
-            "Y": 10,
-            "Tile": 160,
-            "Palette": 1
+            "description": "Remove Left Of Main Elevator Vents To Cold Storage",
+            "x": 7,
+            "y": 10,
+            "tile": 160,
+            "palette": 1
         },
         {
-            "Description": "Remove Right Of Main Elevator Vents To Cold Storage",
-            "X": 8,
-            "Y": 10,
-            "Tile": 160,
-            "Palette": 1
+            "description": "Remove Right Of Main Elevator Vents To Cold Storage",
+            "x": 8,
+            "y": 10,
+            "tile": 160,
+            "palette": 1
         },
         {
-            "Description": "Add Auxillary Power Event Marker",
-            "X": 20,
-            "Y": 19,
-            "Tile": 370,
-            "Palette": 2
+            "description": "Add Auxillary Power Event Marker",
+            "x": 20,
+            "y": 19,
+            "tile": 370,
+            "palette": 2
         },
         {
-            "Description": "Fix Yakuza Boss Tile",
-            "X": 21,
-            "Y": 21,
-            "Tile": 270,
-            "Palette": 2
+            "description": "Fix Yakuza Boss Tile",
+            "x": 21,
+            "y": 21,
+            "tile": 270,
+            "palette": 2
         }
     ],
     "9": [
         {
-            "Description": "Sector 1 Marker from Restricted Lab",
-            "X": 7,
-            "Y": 18,
-            "Tile": 172,
-            "Palette": 0
+            "description": "Sector 1 Marker from Restricted Lab",
+            "x": 7,
+            "y": 18,
+            "tile": 172,
+            "palette": 0
         },
         {
-            "Description": "Sector 1 Elevator Lines from Restricted Lab",
-            "X": 7,
-            "Y": 19,
-            "Tile": 169,
-            "Palette": 2
+            "description": "Sector 1 Elevator Lines from Restricted Lab",
+            "x": 7,
+            "y": 19,
+            "tile": 169,
+            "palette": 2
         },
         {
-            "Description": "Add Item to Quarantine Bay",
-            "X": 8,
-            "Y": 9,
-            "Tile": 386,
-            "Palette": 0
+            "description": "Add Item to Quarantine Bay",
+            "x": 8,
+            "y": 9,
+            "tile": 386,
+            "palette": 0
         },
         {
-            "Description": "Add Item to Subzero Containment",
-            "X": 9,
-            "Y": 10,
-            "Tile": 386,
-            "Palette": 0
+            "description": "Add Item to Subzero Containment",
+            "x": 9,
+            "y": 10,
+            "tile": 386,
+            "palette": 0
         },
         {
-            "Description": "Add L3 Locks to Subzero Containment",
-            "X": 10,
-            "Y": 10,
-            "Tile": 84,
-            "Palette": 0,
+            "description": "Add L3 Locks to Subzero Containment",
+            "x": 10,
+            "y": 10,
+            "tile": 84,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Sector 6 Arrow from Restricted Lab",
-            "X": 10,
-            "Y": 23,
-            "Tile": 170,
-            "Palette": 0,
+            "description": "Sector 6 Arrow from Restricted Lab",
+            "x": 10,
+            "y": 23,
+            "tile": 170,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Sector 6 Marker from Restricted Lab",
-            "X": 11,
-            "Y": 23,
-            "Tile": 177,
-            "Palette": 0
+            "description": "Sector 6 Marker from Restricted Lab",
+            "x": 11,
+            "y": 23,
+            "tile": 177,
+            "palette": 0
         },
         {
-            "Description": "Add L3 Locks to Dark Stairwell",
-            "X": 11,
-            "Y": 10,
-            "Tile": 117,
-            "Palette": 0,
+            "description": "Add L3 Locks to Dark Stairwell",
+            "x": 11,
+            "y": 10,
+            "tile": 117,
+            "palette": 0,
             "VFlip": "True"
         },
         {
-            "Description": "Sector 2 Marker from Central Reactor Core",
-            "X": 14,
-            "Y": 16,
-            "Tile": 173,
-            "Palette": 0
+            "description": "Sector 2 Marker from Central Reactor Core",
+            "x": 14,
+            "y": 16,
+            "tile": 173,
+            "palette": 0
         },
         {
-            "Description": "Connector Arrow to Sector 2 from Central Reactor Core",
-            "X": 15,
-            "Y": 16,
-            "Tile": 164,
-            "Palette": 0,
+            "description": "Connector Arrow to Sector 2 from Central Reactor Core",
+            "x": 15,
+            "y": 16,
+            "tile": 164,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Change Operations Deck Door from L4 to L0",
-            "X": 16,
-            "Y": 0,
-            "Tile": 299,
-            "Palette": 0,
+            "description": "Change Operations Deck Door from L4 to L0",
+            "x": 16,
+            "y": 0,
+            "tile": 299,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Change Operations Deck Door from L4 to L0",
-            "X": 17,
-            "Y": 0,
-            "Tile": 293,
-            "Palette": 0
+            "description": "Change Operations Deck Door from L4 to L0",
+            "x": 17,
+            "y": 0,
+            "tile": 293,
+            "palette": 0
         },
         {
-            "Description": "Change Hidden Concourse Recharge Into Normal Recharge",
-            "X": 17,
-            "Y": 7,
-            "Tile": 344,
-            "Palette": 0
+            "description": "Change Hidden Concourse Recharge Into Normal Recharge",
+            "x": 17,
+            "y": 7,
+            "tile": 344,
+            "palette": 0
         },
         {
-            "Description": "Add Animals Event Marker",
-            "X": 9,
-            "Y": 2,
-            "Tile": 369,
-            "Palette": 0
+            "description": "Add Animals Event Marker",
+            "x": 9,
+            "y": 2,
+            "tile": 369,
+            "palette": 0
         },
         {
-            "Description": "Remove Left Section Of Main Elevator Vents To Cold Storage",
-            "X": 7,
-            "Y": 10,
-            "Tile": 160,
-            "Palette": 1
+            "description": "Remove Left Section Of Main Elevator Vents To Cold Storage",
+            "x": 7,
+            "y": 10,
+            "tile": 160,
+            "palette": 1
         },
         {
-            "Description": "Remove Right Section Of Main Elevator Vents To Cold Storage",
-            "X": 8,
-            "Y": 10,
-            "Tile": 160,
-            "Palette": 1
+            "description": "Remove Right Section Of Main Elevator Vents To Cold Storage",
+            "x": 8,
+            "y": 10,
+            "tile": 160,
+            "palette": 1
         },
         {
-            "Description": "Add Auxillary Power Event Marker",
-            "X": 20,
-            "Y": 19,
-            "Tile": 370,
-            "Palette": 2
+            "description": "Add Auxillary Power Event Marker",
+            "x": 20,
+            "y": 19,
+            "tile": 370,
+            "palette": 2
         },
         {
-            "Description": "Fix Yakuza Boss Tile",
-            "X": 21,
-            "Y": 21,
-            "Tile": 270,
-            "Palette": 2
+            "description": "Fix Yakuza Boss Tile",
+            "x": 21,
+            "y": 21,
+            "tile": 270,
+            "palette": 2
         }
     ],
     "1": [
         {
-            "Description": "Sector 3 Marker",
-            "X": 1,
-            "Y": 2,
-            "Tile": 174,
-            "Palette": 0
+            "description": "Sector 3 Marker",
+            "x": 1,
+            "y": 2,
+            "tile": 174,
+            "palette": 0
         },
         {
-            "Description": "Sector 3 Arrow",
-            "X": 2,
-            "Y": 2,
-            "Tile": 164,
-            "Palette": 2,
+            "description": "Sector 3 Arrow",
+            "x": 2,
+            "y": 2,
+            "tile": 164,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Main Deck Elevator Lines to Restricted Lab",
-            "X": 2,
-            "Y": 13,
-            "Tile": 168,
-            "Palette": 2
+            "description": "Main Deck Elevator Lines to Restricted Lab",
+            "x": 2,
+            "y": 13,
+            "tile": 168,
+            "palette": 2
         },
         {
-            "Description": "Main Deck Marker to Restricted Lab",
-            "X": 2,
-            "Y": 14,
-            "Tile": 171,
-            "Palette": 0
+            "description": "Main Deck Marker to Restricted Lab",
+            "x": 2,
+            "y": 14,
+            "tile": 171,
+            "palette": 0
         },
         {
-            "Description": "Sector 2 Arrow",
-            "X": 9,
-            "Y": 0,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Sector 2 Arrow",
+            "x": 9,
+            "y": 0,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Sector 2 Marker",
-            "X": 10,
-            "Y": 0,
-            "Tile": 173,
-            "Palette": 0
+            "description": "Sector 2 Marker",
+            "x": 10,
+            "y": 0,
+            "tile": 173,
+            "palette": 0
         },
         {
-            "Description": "Add Item to Northeast Stabilizer",
-            "X": 16,
-            "Y": 1,
-            "Tile": 390,
-            "Palette": 0,
+            "description": "Add Item to Northeast Stabilizer",
+            "x": 16,
+            "y": 1,
+            "tile": 390,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Fix Lower Charge Core Access Hall",
-            "X": 12,
-            "Y": 6,
-            "Tile": 299,
-            "Palette": 0
+            "description": "Fix Lower Charge Core Access Hall",
+            "x": 12,
+            "y": 6,
+            "tile": 299,
+            "palette": 0
         },
         {
-            "Description": "Add Charge Core Boss Tile",
-            "X": 9,
-            "Y": 6,
-            "Tile": 267,
-            "Palette": 0,
+            "description": "Add Charge Core Boss Tile",
+            "x": 9,
+            "y": 6,
+            "tile": 267,
+            "palette": 0,
             "HFlip": "True"
         }
     ],
     "2": [
         {
-            "Description": "Sector 1 Marker",
-            "X": 1,
-            "Y": 3,
-            "Tile": 172,
-            "Palette": 0
+            "description": "Sector 1 Marker",
+            "x": 1,
+            "y": 3,
+            "tile": 172,
+            "palette": 0
         },
         {
-            "Description": "Sector 1 Arrow",
-            "X": 2,
-            "Y": 3,
-            "Tile": 164,
-            "Palette": 2,
+            "description": "Sector 1 Arrow",
+            "x": 2,
+            "y": 3,
+            "tile": 164,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Add Upper Level One Security Section",
-            "X": 9,
-            "Y": 0,
-            "Tile": 368,
-            "Palette": 0
+            "description": "Add Upper Level One Security Section",
+            "x": 9,
+            "y": 0,
+            "tile": 368,
+            "palette": 0
         },
         {
-            "Description": "Add Lower Level One Security Section",
-            "X": 9,
-            "Y": 1,
-            "Tile": 364,
-            "Palette": 0
+            "description": "Add Lower Level One Security Section",
+            "x": 9,
+            "y": 1,
+            "tile": 364,
+            "palette": 0
         },
         {
-            "Description": "Sector 4 Arrow",
-            "X": 12,
-            "Y": 2,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Sector 4 Arrow",
+            "x": 12,
+            "y": 2,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Sector 4 Marker",
-            "X": 13,
-            "Y": 2,
-            "Tile": 175,
-            "Palette": 0
+            "description": "Sector 4 Marker",
+            "x": 13,
+            "y": 2,
+            "tile": 175,
+            "palette": 0
         },
         {
-            "Description": "Add Nettori Boss Tile",
-            "X": 13,
-            "Y": 6,
-            "Tile": 267,
-            "Palette": 2,
+            "description": "Add Nettori Boss Tile",
+            "x": 13,
+            "y": 6,
+            "tile": 267,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Fix Zazabi Boss Tile",
-            "X": 14,
-            "Y": 13,
-            "Tile": 267,
-            "Palette": 2
+            "description": "Fix Zazabi Boss Tile",
+            "x": 14,
+            "y": 13,
+            "tile": 267,
+            "palette": 2
         },
         {
-            "Description": "Main Deck Arrow to Reactor Core",
-            "X": 17,
-            "Y": 8,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Main Deck Arrow to Reactor Core",
+            "x": 17,
+            "y": 8,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Main Deck Marker to Reactor Core",
-            "X": 18,
-            "Y": 8,
-            "Tile": 171,
-            "Palette": 0
+            "description": "Main Deck Marker to Reactor Core",
+            "x": 18,
+            "y": 8,
+            "tile": 171,
+            "palette": 0
         }
     ],
     "3": [
         {
-            "Description": "Sector 5 Marker",
-            "X": 0,
-            "Y": 4,
-            "Tile": 176,
-            "Palette": 0
+            "description": "Sector 5 Marker",
+            "x": 0,
+            "y": 4,
+            "tile": 176,
+            "palette": 0
         },
         {
-            "Description": "Remove Extra tile left of Level Two Security",
-            "X": 2,
-            "Y": 5,
-            "Tile": 160,
-            "Palette": 0
+            "description": "Remove Extra tile left of Level Two Security",
+            "x": 2,
+            "y": 5,
+            "tile": 160,
+            "palette": 0
         },
         {
-            "Description": "Add Level Two Security Tile",
-            "X": 3,
-            "Y": 5,
-            "Tile": 365,
-            "Palette": 0
+            "description": "Add Level Two Security Tile",
+            "x": 3,
+            "y": 5,
+            "tile": 365,
+            "palette": 0
         },
         {
-            "Description": "Add Boiler Pad Event Tile",
-            "X": 3,
-            "Y": 8,
-            "Tile": 262,
-            "Palette": 0
+            "description": "Add Boiler Pad Event Tile",
+            "x": 3,
+            "y": 8,
+            "tile": 262,
+            "palette": 0
         },
         {
-            "Description": "Add Boss Marker To Boiler Control",
-            "X": 4,
-            "Y": 8,
-            "Tile": 267,
-            "Palette": 0
+            "description": "Add Boss Marker To Boiler Control",
+            "x": 4,
+            "y": 8,
+            "tile": 267,
+            "palette": 0
         },
         {
-            "Description": "Fix Entrance Recharge Room",
-            "X": 7,
-            "Y": 2,
-            "Tile": 346,
-            "Palette": 0
+            "description": "Fix Entrance Recharge Room",
+            "x": 7,
+            "y": 2,
+            "tile": 346,
+            "palette": 0
         },
         {
-            "Description": "Add Box Boss Tile Functions Similar To Serris Hallway",
-            "X": 17,
-            "Y": 3,
-            "Tile": 264,
-            "Palette": 0
+            "description": "Add Box Boss Tile Functions Similar To Serris Hallway",
+            "x": 17,
+            "y": 3,
+            "tile": 264,
+            "palette": 0
         },
         {
-            "Description": "Sector 1 Arrow",
-            "X": 18,
-            "Y": 0,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Sector 1 Arrow",
+            "x": 18,
+            "y": 0,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Sector 1 Marker",
-            "X": 19,
-            "Y": 0,
-            "Tile": 172,
-            "Palette": 0
+            "description": "Sector 1 Marker",
+            "x": 19,
+            "y": 0,
+            "tile": 172,
+            "palette": 0
         }
     ],
     "4": [
         {
-            "Description": "Sector 5 Marker",
-            "X": 3,
-            "Y": 8,
-            "Tile": 176,
-            "Palette": 0
+            "description": "Sector 5 Marker",
+            "x": 3,
+            "y": 8,
+            "tile": 176,
+            "palette": 0
         },
         {
-            "Description": "Add Level Four Security Tile",
-            "X": 3,
-            "Y": 14,
-            "Tile": 366,
-            "Palette": 0
+            "description": "Add Level Four Security Tile",
+            "x": 3,
+            "y": 14,
+            "tile": 366,
+            "palette": 0
         },
         {
-            "Description": "Sector 5 Arrow",
-            "X": 4,
-            "Y": 8,
-            "Tile": 164,
-            "Palette": 2,
+            "description": "Sector 5 Arrow",
+            "x": 4,
+            "y": 8,
+            "tile": 164,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Add Level Four Hatch To Security Access To Cheddar Bay",
-            "X": 4,
-            "Y": 11,
-            "Tile": 114,
-            "Palette": 0,
+            "description": "Add Level Four Hatch To Security Access To Cheddar Bay",
+            "x": 4,
+            "y": 11,
+            "tile": 114,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Add Level Four Hatch To Security Access to Level Four Security",
-            "X": 4,
-            "Y": 14,
-            "Tile": 114,
-            "Palette": 0,
+            "description": "Add Level Four Hatch To Security Access to Level Four Security",
+            "x": 4,
+            "y": 14,
+            "tile": 114,
+            "palette": 0,
             "VFlip": "True"
         },
         {
-            "Description": "Add Level Four Hatch To Cheddar Bay To Security Access",
-            "X": 5,
-            "Y": 11,
-            "Tile": 79,
-            "Palette": 0
+            "description": "Add Level Four Hatch To Cheddar Bay To Security Access",
+            "x": 5,
+            "y": 11,
+            "tile": 79,
+            "palette": 0
         },
         {
-            "Description": "Fix Top Left Serris Arena Corner",
-            "X": 10,
-            "Y": 0,
-            "Tile": 0,
-            "Palette": 0
+            "description": "Fix Top Left Serris Arena Corner",
+            "x": 10,
+            "y": 0,
+            "tile": 0,
+            "palette": 0
         },
         {
-            "Description": "Add New Serris Arena Boss Tile",
-            "X": 11,
-            "Y": 0,
-            "Tile": 266,
-            "Palette": 0
+            "description": "Add New Serris Arena Boss Tile",
+            "x": 11,
+            "y": 0,
+            "tile": 266,
+            "palette": 0
         },
         {
-            "Description": "Sector 2 Marker",
-            "X": 18,
-            "Y": 11,
-            "Tile": 173,
-            "Palette": 0
+            "description": "Sector 2 Marker",
+            "x": 18,
+            "y": 11,
+            "tile": 173,
+            "palette": 0
         },
         {
-            "Description": "Sector 2 Arrow",
-            "X": 19,
-            "Y": 11,
-            "Tile": 164,
-            "Palette": 2,
+            "description": "Sector 2 Arrow",
+            "x": 19,
+            "y": 11,
+            "tile": 164,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Add Level Four Hatch To Owtch Atrium To Powamp Playhouse",
-            "X": 19,
-            "Y": 5,
-            "Tile": 240,
-            "Palette": 0,
+            "description": "Add Level Four Hatch To Owtch Atrium To Powamp Playhouse",
+            "x": 19,
+            "y": 5,
+            "tile": 240,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Sector 6 Arrow",
-            "X": 22,
-            "Y": 5,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Sector 6 Arrow",
+            "x": 22,
+            "y": 5,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Sector 6 Marker",
-            "X": 23,
-            "Y": 5,
-            "Tile": 177,
-            "Palette": 0
+            "description": "Sector 6 Marker",
+            "x": 23,
+            "y": 5,
+            "tile": 177,
+            "palette": 0
         }
     ],
     "5": [
         {
-            "Description": "Sector 6 Marker",
-            "X": 0,
-            "Y": 4,
-            "Tile": 177,
-            "Palette": 0
+            "description": "Sector 6 Marker",
+            "x": 0,
+            "y": 4,
+            "tile": 177,
+            "palette": 0
         },
         {
-            "Description": "Sector 6 Arrow",
-            "X": 1,
-            "Y": 4,
-            "Tile": 164,
-            "Palette": 2,
+            "description": "Sector 6 Arrow",
+            "x": 1,
+            "y": 4,
+            "tile": 164,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Add Level Three Hatch To Magic Box",
-            "X": 3,
-            "Y": 4,
-            "Tile": 430,
-            "Palette": 0,
+            "description": "Add Level Three Hatch To Magic Box",
+            "x": 3,
+            "y": 4,
+            "tile": 430,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Add Level Three Security Tile",
-            "X": 6,
-            "Y": 10,
-            "Tile": 367,
-            "Palette": 2
+            "description": "Add Level Three Security Tile",
+            "x": 6,
+            "y": 10,
+            "tile": 367,
+            "palette": 2
         },
         {
-            "Description": "Change Level 4 Door to Level 3 Door in Arctic Containment",
-            "X": 10,
-            "Y": 4,
-            "Tile": 20,
-            "Palette": 0,
+            "description": "Change Level 4 Door to Level 3 Door in Arctic Containment",
+            "x": 10,
+            "y": 4,
+            "tile": 20,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Change Level 4 Door to Level 3 Door in Crows Nest",
-            "X": 11,
-            "Y": 4,
-            "Tile": 245,
-            "Palette": 0,
+            "description": "Change Level 4 Door to Level 3 Door in Crows Nest",
+            "x": 11,
+            "y": 4,
+            "tile": 245,
+            "palette": 0,
             "HFlip": "True"
         },
         {
-            "Description": "Sector 3 Arrow",
-            "X": 12,
-            "Y": 3,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Sector 3 Arrow",
+            "x": 12,
+            "y": 3,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Sector 3 Marker",
-            "X": 13,
-            "Y": 3,
-            "Tile": 174,
-            "Palette": 0
+            "description": "Sector 3 Marker",
+            "x": 13,
+            "y": 3,
+            "tile": 174,
+            "palette": 0
         },
         {
-            "Description": "Flooded Tower",
-            "X": 16,
-            "Y": 5,
-            "Tile": 97,
-            "Palette": 2
+            "description": "Flooded Tower",
+            "x": 16,
+            "y": 5,
+            "tile": 97,
+            "palette": 2
         },
         {
-            "Description": "Ruined Break Room",
-            "X": 17,
-            "Y": 5,
-            "Tile": 384,
-            "Palette": 2,
+            "description": "Ruined Break Room",
+            "x": 17,
+            "y": 5,
+            "tile": 384,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Sector 4 Arrow",
-            "X": 22,
-            "Y": 8,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Sector 4 Arrow",
+            "x": 22,
+            "y": 8,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Sector 4 Marker",
-            "X": 23,
-            "Y": 8,
-            "Tile": 175,
-            "Palette": 0
+            "description": "Sector 4 Marker",
+            "x": 23,
+            "y": 8,
+            "tile": 175,
+            "palette": 0
         }
     ],
     "6": [
         {
-            "Description": "Main Deck Marker to Restricted Lab",
-            "X": 0,
-            "Y": 9,
-            "Tile": 171,
-            "Palette": 0
+            "description": "Main Deck Marker to Restricted Lab",
+            "x": 0,
+            "y": 9,
+            "tile": 171,
+            "palette": 0
         },
         {
-            "Description": "Sector 4 Marker",
-            "X": 1,
-            "Y": 3,
-            "Tile": 175,
-            "Palette": 0
+            "description": "Sector 4 Marker",
+            "x": 1,
+            "y": 3,
+            "tile": 175,
+            "palette": 0
         },
         {
-            "Description": "Sector 4 Arrow",
-            "X": 2,
-            "Y": 3,
-            "Tile": 164,
-            "Palette": 2,
+            "description": "Sector 4 Arrow",
+            "x": 2,
+            "y": 3,
+            "tile": 164,
+            "palette": 2,
             "HFlip": "True"
         },
         {
-            "Description": "Add Xbox Boss Tile",
-            "X": 7,
-            "Y": 6,
-            "Tile": 268,
-            "Palette": 2
+            "description": "Add Xbox Boss Tile",
+            "x": 7,
+            "y": 6,
+            "tile": 268,
+            "palette": 2
         },
         {
-            "Description": "Sector 5 Arrow",
-            "X": 12,
-            "Y": 2,
-            "Tile": 164,
-            "Palette": 2
+            "description": "Sector 5 Arrow",
+            "x": 12,
+            "y": 2,
+            "tile": 164,
+            "palette": 2
         },
         {
-            "Description": "Sector 5 Marker",
-            "X": 13,
-            "Y": 2,
-            "Tile": 176,
-            "Palette": 0
+            "description": "Sector 5 Marker",
+            "x": 13,
+            "y": 2,
+            "tile": 176,
+            "palette": 0
         }
     ]
 }

--- a/src/mars_patcher/mf/data/locations.json
+++ b/src/mars_patcher/mf/data/locations.json
@@ -1,974 +1,974 @@
 {
-    "MajorLocations": [
+    "major_locations": [
         {
-            "Area": 0,
-            "Room": 39,
-            "Source": "MainDeckData",
-            "Original": "Missiles"
+            "area": 0,
+            "room": 39,
+            "source": "MAIN_DECK_DATA",
+            "original": "MISSILES"
         },
         {
-            "Area": 0,
-            "Room": 38,
-            "Source": "Arachnus",
-            "Original": "MorphBall"
+            "area": 0,
+            "room": 38,
+            "source": "ARACHNUS",
+            "original": "MORPH_BALL"
         },
         {
-            "Area": 1,
-            "Room": 40,
-            "Source": "ChargeCoreX",
-            "Original": "ChargeBeam"
+            "area": 1,
+            "room": 40,
+            "source": "CHARGE_CORE_X",
+            "original": "CHARGE_BEAM"
         },
         {
-            "Area": 2,
-            "Room": 26,
-            "Source": "Level1",
-            "Original": "Level1"
+            "area": 2,
+            "room": 26,
+            "source": "LEVEL_1",
+            "original": "LEVEL_1"
         },
         {
-            "Area": 2,
-            "Room": 8,
-            "Source": "TroData",
-            "Original": "Bombs"
+            "area": 2,
+            "room": 8,
+            "source": "TRO_DATA",
+            "original": "BOMBS"
         },
         {
-            "Area": 2,
-            "Room": 18,
-            "Source": "Zazabi",
-            "Original": "HiJump"
+            "area": 2,
+            "room": 18,
+            "source": "ZAZABI",
+            "original": "HI_JUMP"
         },
         {
-            "Area": 4,
-            "Room": 42,
-            "Source": "Serris",
-            "Original": "SpeedBooster"
+            "area": 4,
+            "room": 42,
+            "source": "SERRIS",
+            "original": "SPEED_BOOSTER"
         },
         {
-            "Area": 3,
-            "Room": 4,
-            "Source": "Level2",
-            "Original": "Level2"
+            "area": 3,
+            "room": 4,
+            "source": "LEVEL_2",
+            "original": "LEVEL_2"
         },
         {
-            "Area": 3,
-            "Room": 21,
-            "Source": "PyrData",
-            "Original": "SuperMissiles"
+            "area": 3,
+            "room": 21,
+            "source": "PYR_DATA",
+            "original": "SUPER_MISSILES"
         },
         {
-            "Area": 6,
-            "Room": 13,
-            "Source": "MegaX",
-            "Original": "VariaSuit"
+            "area": 6,
+            "room": 13,
+            "source": "MEGA_X",
+            "original": "VARIA_SUIT"
         },
         {
-            "Area": 5,
-            "Room": 10,
-            "Source": "Level3",
-            "Original": "Level3"
+            "area": 5,
+            "room": 10,
+            "source": "LEVEL_3",
+            "original": "LEVEL_3"
         },
         {
-            "Area": 5,
-            "Room": 5,
-            "Source": "ArcData1",
-            "Original": "IceMissiles"
+            "area": 5,
+            "room": 5,
+            "source": "ARC_DATA_1",
+            "original": "ICE_MISSILES"
         },
         {
-            "Area": 3,
-            "Room": 25,
-            "Source": "WideCoreX",
-            "Original": "WideBeam"
+            "area": 3,
+            "room": 25,
+            "source": "WIDE_CORE_X",
+            "original": "WIDE_BEAM"
         },
         {
-            "Area": 5,
-            "Room": 5,
-            "Source": "ArcData2",
-            "Original": "PowerBombs"
+            "area": 5,
+            "room": 5,
+            "source": "ARC_DATA_2",
+            "original": "POWER_BOMBS"
         },
         {
-            "Area": 0,
-            "Room": 86,
-            "Source": "Yakuza",
-            "Original": "SpaceJump"
+            "area": 0,
+            "room": 86,
+            "source": "YAKUZA",
+            "original": "SPACE_JUMP"
         },
         {
-            "Area": 2,
-            "Room": 22,
-            "Source": "Nettori",
-            "Original": "PlasmaBeam"
+            "area": 2,
+            "room": 22,
+            "source": "NETTORI",
+            "original": "PLASMA_BEAM"
         },
         {
-            "Area": 5,
-            "Room": 20,
-            "Source": "Nightmare",
-            "Original": "GravitySuit"
+            "area": 5,
+            "room": 20,
+            "source": "NIGHTMARE",
+            "original": "GRAVITY_SUIT"
         },
         {
-            "Area": 4,
-            "Room": 26,
-            "Source": "Level4",
-            "Original": "Level4"
+            "area": 4,
+            "room": 26,
+            "source": "LEVEL_4",
+            "original": "LEVEL_4"
         },
         {
-            "Area": 4,
-            "Room": 4,
-            "Source": "AqaData",
-            "Original": "DiffusionMissiles"
+            "area": 4,
+            "room": 4,
+            "source": "AQA_DATA",
+            "original": "DIFFUSION_MISSILES"
         },
         {
-            "Area": 6,
-            "Room": 16,
-            "Source": "WaveCoreX",
-            "Original": "WaveBeam"
+            "area": 6,
+            "room": 16,
+            "source": "WAVE_CORE_X",
+            "original": "WAVE_BEAM"
         },
         {
-            "Area": 1,
-            "Room": 27,
-            "Source": "Ridley",
-            "Original": "ScrewAttack"
+            "area": 1,
+            "room": 27,
+            "source": "RIDLEY",
+            "original": "SCREW_ATTACK"
         },
         {
-            "Area": 3,
-            "Room": 25,
-            "Source": "Boiler",
-            "Original": "InfantMetroid"
+            "area": 3,
+            "room": 25,
+            "source": "BOILER",
+            "original": "INFANT_METROID"
         },
         {
-            "Area": 0,
-            "Room": 69,
-            "Source": "Animals",
-            "Original": "InfantMetroid"
+            "area": 0,
+            "room": 69,
+            "source": "ANIMALS",
+            "original": "INFANT_METROID"
         },
         {
-            "Area": 0,
-            "Room": 54,
-            "Source": "AuxiliaryPower",
-            "Original": "InfantMetroid"
+            "area": 0,
+            "room": 54,
+            "source": "AUXILIARY_POWER",
+            "original": "INFANT_METROID"
         }
     ],
-    "MinorLocations": [
-        {
-            "Area": 0,
-            "Room": 7,
-            "BlockX": 13,
-            "BlockY": 14,
-            "Hidden": true,
-            "Original": "MissileTank"
+    "minor_locations": [
+        {
+            "area": 0,
+            "room": 7,
+            "block_x": 13,
+            "block_y": 14,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 17,
-            "BlockX": 9,
-            "BlockY": 20,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 0,
+            "room": 17,
+            "block_x": 9,
+            "block_y": 20,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 35,
-            "BlockX": 14,
-            "BlockY": 65,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 0,
+            "room": 35,
+            "block_x": 14,
+            "block_y": 65,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 38,
-            "BlockX": 53,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 0,
+            "room": 38,
+            "block_x": 53,
+            "block_y": 10,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 45,
-            "BlockX": 4,
-            "BlockY": 6,
-            "Hidden": true,
-            "Original": "MissileTank"
+        {
+            "area": 0,
+            "room": 45,
+            "block_x": 4,
+            "block_y": 6,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 46,
-            "BlockX": 9,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "InfantMetroid"
+        {
+            "area": 0,
+            "room": 46,
+            "block_x": 9,
+            "block_y": 8,
+            "hidden": false,
+            "original": "INFANT_METROID"
         },
-        {
-            "Area": 0,
-            "Room": 47,
-            "BlockX": 4,
-            "BlockY": 3,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 0,
+            "room": 47,
+            "block_x": 4,
+            "block_y": 3,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 50,
-            "BlockX": 54,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 0,
+            "room": 50,
+            "block_x": 54,
+            "block_y": 8,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 51,
-            "BlockX": 5,
-            "BlockY": 29,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 0,
+            "room": 51,
+            "block_x": 5,
+            "block_y": 29,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 57,
-            "BlockX": 12,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 0,
+            "room": 57,
+            "block_x": 12,
+            "block_y": 10,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 69,
-            "BlockX": 29,
-            "BlockY": 29,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 0,
+            "room": 69,
+            "block_x": 29,
+            "block_y": 29,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 71,
-            "BlockX": 6,
-            "BlockY": 9,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 0,
+            "room": 71,
+            "block_x": 6,
+            "block_y": 9,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 72,
-            "BlockX": 13,
-            "BlockY": 9,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 0,
+            "room": 72,
+            "block_x": 13,
+            "block_y": 9,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 73,
-            "BlockX": 6,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 0,
+            "room": 73,
+            "block_x": 6,
+            "block_y": 10,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 0,
-            "Room": 84,
-            "BlockX": 14,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 0,
+            "room": 84,
+            "block_x": 14,
+            "block_y": 10,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 5,
-            "BlockX": 27,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 1,
+            "room": 5,
+            "block_x": 27,
+            "block_y": 10,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 17,
-            "BlockX": 8,
-            "BlockY": 6,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 1,
+            "room": 17,
+            "block_x": 8,
+            "block_y": 6,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 17,
-            "BlockX": 25,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 1,
+            "room": 17,
+            "block_x": 25,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 17,
-            "BlockX": 44,
-            "BlockY": 19,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 1,
+            "room": 17,
+            "block_x": 44,
+            "block_y": 19,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 30,
-            "BlockX": 15,
-            "BlockY": 8,
-            "Hidden": true,
-            "Original": "EnergyTank"
+        {
+            "area": 1,
+            "room": 30,
+            "block_x": 15,
+            "block_y": 8,
+            "hidden": true,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 32,
-            "BlockX": 29,
-            "BlockY": 9,
-            "Hidden": false,
-            "Original": "InfantMetroid"
+        {
+            "area": 1,
+            "room": 32,
+            "block_x": 29,
+            "block_y": 9,
+            "hidden": false,
+            "original": "INFANT_METROID"
         },
-        {
-            "Area": 1,
-            "Room": 39,
-            "BlockX": 4,
-            "BlockY": 6,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 1,
+            "room": 39,
+            "block_x": 4,
+            "block_y": 6,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 40,
-            "BlockX": 12,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 1,
+            "room": 40,
+            "block_x": 12,
+            "block_y": 8,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 43,
-            "BlockX": 13,
-            "BlockY": 11,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 1,
+            "room": 43,
+            "block_x": 13,
+            "block_y": 11,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 44,
-            "BlockX": 4,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 1,
+            "room": 44,
+            "block_x": 4,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 47,
-            "BlockX": 10,
-            "BlockY": 2,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 1,
+            "room": 47,
+            "block_x": 10,
+            "block_y": 2,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 50,
-            "BlockX": 6,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 1,
+            "room": 50,
+            "block_x": 6,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 1,
-            "Room": 52,
-            "BlockX": 13,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 1,
+            "room": 52,
+            "block_x": 13,
+            "block_y": 7,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 6,
-            "BlockX": 29,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 6,
+            "block_x": 29,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 9,
-            "BlockX": 13,
-            "BlockY": 4,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 9,
+            "block_x": 13,
+            "block_y": 4,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 10,
-            "BlockX": 19,
-            "BlockY": 35,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 10,
+            "block_x": 19,
+            "block_y": 35,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 17,
-            "BlockX": 44,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 2,
+            "room": 17,
+            "block_x": 44,
+            "block_y": 7,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 21,
-            "BlockX": 29,
-            "BlockY": 4,
-            "Hidden": true,
-            "Original": "EnergyTank"
+        {
+            "area": 2,
+            "room": 21,
+            "block_x": 29,
+            "block_y": 4,
+            "hidden": true,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 25,
-            "BlockX": 4,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 25,
+            "block_x": 4,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 27,
-            "BlockX": 28,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 27,
+            "block_x": 28,
+            "block_y": 7,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 31,
-            "BlockX": 40,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 31,
+            "block_x": 40,
+            "block_y": 7,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 33,
-            "BlockX": 21,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 33,
+            "block_x": 21,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 42,
-            "BlockX": 5,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 42,
+            "block_x": 5,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 47,
-            "BlockX": 29,
-            "BlockY": 16,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 2,
+            "room": 47,
+            "block_x": 29,
+            "block_y": 16,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 50,
-            "BlockX": 3,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 2,
+            "room": 50,
+            "block_x": 3,
+            "block_y": 7,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 50,
-            "BlockX": 3,
-            "BlockY": 24,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 2,
+            "room": 50,
+            "block_x": 3,
+            "block_y": 24,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 54,
-            "BlockX": 4,
-            "BlockY": 5,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 2,
+            "room": 54,
+            "block_x": 4,
+            "block_y": 5,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 54,
-            "BlockX": 9,
-            "BlockY": 14,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 2,
+            "room": 54,
+            "block_x": 9,
+            "block_y": 14,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 55,
-            "BlockX": 7,
-            "BlockY": 4,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 2,
+            "room": 55,
+            "block_x": 7,
+            "block_y": 4,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 2,
-            "Room": 55,
-            "BlockX": 10,
-            "BlockY": 26,
-            "Hidden": true,
-            "Original": "MissileTank"
+        {
+            "area": 2,
+            "room": 55,
+            "block_x": 10,
+            "block_y": 26,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 3,
-            "BlockX": 44,
-            "BlockY": 13,
-            "Hidden": true,
-            "Original": "MissileTank"
+        {
+            "area": 3,
+            "room": 3,
+            "block_x": 44,
+            "block_y": 13,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 6,
-            "BlockX": 5,
-            "BlockY": 17,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 3,
+            "room": 6,
+            "block_x": 5,
+            "block_y": 17,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 8,
-            "BlockX": 9,
-            "BlockY": 9,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 3,
+            "room": 8,
+            "block_x": 9,
+            "block_y": 9,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 8,
-            "BlockX": 22,
-            "BlockY": 13,
-            "Hidden": true,
-            "Original": "EnergyTank"
+        {
+            "area": 3,
+            "room": 8,
+            "block_x": 22,
+            "block_y": 13,
+            "hidden": true,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 9,
-            "BlockX": 42,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 3,
+            "room": 9,
+            "block_x": 42,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 12,
-            "BlockX": 12,
-            "BlockY": 25,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 3,
+            "room": 12,
+            "block_x": 12,
+            "block_y": 25,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 19,
-            "BlockX": 19,
-            "BlockY": 13,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 3,
+            "room": 19,
+            "block_x": 19,
+            "block_y": 13,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 19,
-            "BlockX": 43,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 3,
+            "room": 19,
+            "block_x": 43,
+            "block_y": 10,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 28,
-            "BlockX": 12,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 3,
+            "room": 28,
+            "block_x": 12,
+            "block_y": 7,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 28,
-            "BlockX": 36,
-            "BlockY": 27,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 3,
+            "room": 28,
+            "block_x": 36,
+            "block_y": 27,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 30,
-            "BlockX": 4,
-            "BlockY": 13,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 3,
+            "room": 30,
+            "block_x": 4,
+            "block_y": 13,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 33,
-            "BlockX": 15,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 3,
+            "room": 33,
+            "block_x": 15,
+            "block_y": 10,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 34,
-            "BlockX": 10,
-            "BlockY": 15,
-            "Hidden": true,
-            "Original": "MissileTank"
+        {
+            "area": 3,
+            "room": 34,
+            "block_x": 10,
+            "block_y": 15,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 35,
-            "BlockX": 4,
-            "BlockY": 27,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 3,
+            "room": 35,
+            "block_x": 4,
+            "block_y": 27,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 35,
-            "BlockX": 15,
-            "BlockY": 86,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 3,
+            "room": 35,
+            "block_x": 15,
+            "block_y": 86,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 3,
-            "Room": 37,
-            "BlockX": 15,
-            "BlockY": 3,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 3,
+            "room": 37,
+            "block_x": 15,
+            "block_y": 3,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 6,
-            "BlockX": 22,
-            "BlockY": 29,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 4,
+            "room": 6,
+            "block_x": 22,
+            "block_y": 29,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 10,
-            "BlockX": 12,
-            "BlockY": 29,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 4,
+            "room": 10,
+            "block_x": 12,
+            "block_y": 29,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 13,
-            "BlockX": 24,
-            "BlockY": 9,
-            "Hidden": true,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 13,
+            "block_x": 24,
+            "block_y": 9,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 13,
-            "BlockX": 38,
-            "BlockY": 15,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 13,
+            "block_x": 38,
+            "block_y": 15,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 15,
-            "BlockX": 44,
-            "BlockY": 5,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 15,
+            "block_x": 44,
+            "block_y": 5,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 17,
-            "BlockX": 23,
-            "BlockY": 20,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 17,
+            "block_x": 23,
+            "block_y": 20,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 23,
-            "BlockX": 57,
-            "BlockY": 19,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 4,
+            "room": 23,
+            "block_x": 57,
+            "block_y": 19,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 24,
-            "BlockX": 40,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 4,
+            "room": 24,
+            "block_x": 40,
+            "block_y": 7,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 28,
-            "BlockX": 9,
-            "BlockY": 6,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 28,
+            "block_x": 9,
+            "block_y": 6,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 33,
-            "BlockX": 10,
-            "BlockY": 13,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 33,
+            "block_x": 10,
+            "block_y": 13,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 36,
-            "BlockX": 3,
-            "BlockY": 7,
-            "Hidden": true,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 36,
+            "block_x": 3,
+            "block_y": 7,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 38,
-            "BlockX": 22,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 38,
+            "block_x": 22,
+            "block_y": 10,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 38,
-            "BlockX": 42,
-            "BlockY": 5,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 4,
+            "room": 38,
+            "block_x": 42,
+            "block_y": 5,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 41,
-            "BlockX": 15,
-            "BlockY": 4,
-            "Hidden": true,
-            "Original": "EnergyTank"
+        {
+            "area": 4,
+            "room": 41,
+            "block_x": 15,
+            "block_y": 4,
+            "hidden": true,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 4,
-            "Room": 46,
-            "BlockX": 4,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 4,
+            "room": 46,
+            "block_x": 4,
+            "block_y": 10,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 4,
-            "BlockX": 5,
-            "BlockY": 5,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 4,
+            "block_x": 5,
+            "block_y": 5,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 4,
-            "BlockX": 20,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 5,
+            "room": 4,
+            "block_x": 20,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 12,
-            "BlockX": 3,
-            "BlockY": 10,
-            "Hidden": true,
-            "Original": "EnergyTank"
+        {
+            "area": 5,
+            "room": 12,
+            "block_x": 3,
+            "block_y": 10,
+            "hidden": true,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 14,
-            "BlockX": 13,
-            "BlockY": 3,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 5,
+            "room": 14,
+            "block_x": 13,
+            "block_y": 3,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 18,
-            "BlockX": 3,
-            "BlockY": 3,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 18,
+            "block_x": 3,
+            "block_y": 3,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 22,
-            "BlockX": 3,
-            "BlockY": 48,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 22,
+            "block_x": 3,
+            "block_y": 48,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 23,
-            "BlockX": 14,
-            "BlockY": 6,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 23,
+            "block_x": 14,
+            "block_y": 6,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 26,
-            "BlockX": 4,
-            "BlockY": 6,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 26,
+            "block_x": 4,
+            "block_y": 6,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 30,
-            "BlockX": 23,
-            "BlockY": 7,
-            "Hidden": false,
-            "Original": "MissileTank"
+        {
+            "area": 5,
+            "room": 30,
+            "block_x": 23,
+            "block_y": 7,
+            "hidden": false,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 33,
-            "BlockX": 14,
-            "BlockY": 3,
-            "Hidden": true,
-            "Original": "MissileTank"
+        {
+            "area": 5,
+            "room": 33,
+            "block_x": 14,
+            "block_y": 3,
+            "hidden": true,
+            "original": "MISSILE_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 34,
-            "BlockX": 14,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "EnergyTank"
+        {
+            "area": 5,
+            "room": 34,
+            "block_x": 14,
+            "block_y": 8,
+            "hidden": false,
+            "original": "ENERGY_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 36,
-            "BlockX": 8,
-            "BlockY": 8,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 36,
+            "block_x": 8,
+            "block_y": 8,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 47,
-            "BlockX": 4,
-            "BlockY": 10,
-            "Hidden": true,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 47,
+            "block_x": 4,
+            "block_y": 10,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 50,
-            "BlockX": 13,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 50,
+            "block_x": 13,
+            "block_y": 8,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         },
-        {
-            "Area": 5,
-            "Room": 51,
-            "BlockX": 11,
-            "BlockY": 3,
-            "Hidden": true,
-            "Original": "MissileTank"
-        },
-        {
-            "Area": 6,
-            "Room": 0,
-            "BlockX": 41,
-            "BlockY": 18,
-            "Hidden": false,
-            "Original": "MissileTank"
-        },
-        {
-            "Area": 6,
-            "Room": 15,
-            "BlockX": 3,
-            "BlockY": 3,
-            "Hidden": true,
-            "Original": "MissileTank"
-        },
-        {
-            "Area": 6,
-            "Room": 18,
-            "BlockX": 15,
-            "BlockY": 3,
-            "Hidden": true,
-            "Original": "PowerBombTank"
-        },
-        {
-            "Area": 6,
-            "Room": 18,
-            "BlockX": 29,
-            "BlockY": 20,
-            "Hidden": false,
-            "Original": "MissileTank"
-        },
-        {
-            "Area": 6,
-            "Room": 24,
-            "BlockX": 29,
-            "BlockY": 9,
-            "Hidden": false,
-            "Original": "MissileTank"
-        },
-        {
-            "Area": 6,
-            "Room": 26,
-            "BlockX": 5,
-            "BlockY": 6,
-            "Hidden": false,
-            "Original": "EnergyTank"
-        },
-        {
-            "Area": 6,
-            "Room": 30,
-            "BlockX": 9,
-            "BlockY": 13,
-            "Hidden": true,
-            "Original": "MissileTank"
-        },
-        {
-            "Area": 6,
-            "Room": 30,
-            "BlockX": 19,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "MissileTank"
-        },
-        {
-            "Area": 6,
-            "Room": 34,
-            "BlockX": 14,
-            "BlockY": 8,
-            "Hidden": false,
-            "Original": "EnergyTank"
-        },
-        {
-            "Area": 6,
-            "Room": 38,
-            "BlockX": 45,
-            "BlockY": 6,
-            "Hidden": false,
-            "Original": "EnergyTank"
-        },
-        {
-            "Area": 6,
-            "Room": 39,
-            "BlockX": 10,
-            "BlockY": 24,
-            "Hidden": false,
-            "Original": "PowerBombTank"
-        },
-        {
-            "Area": 6,
-            "Room": 39,
-            "BlockX": 33,
-            "BlockY": 10,
-            "Hidden": false,
-            "Original": "PowerBombTank"
+        {
+            "area": 5,
+            "room": 51,
+            "block_x": 11,
+            "block_y": 3,
+            "hidden": true,
+            "original": "MISSILE_TANK"
+        },
+        {
+            "area": 6,
+            "room": 0,
+            "block_x": 41,
+            "block_y": 18,
+            "hidden": false,
+            "original": "MISSILE_TANK"
+        },
+        {
+            "area": 6,
+            "room": 15,
+            "block_x": 3,
+            "block_y": 3,
+            "hidden": true,
+            "original": "MISSILE_TANK"
+        },
+        {
+            "area": 6,
+            "room": 18,
+            "block_x": 15,
+            "block_y": 3,
+            "hidden": true,
+            "original": "POWER_BOMB_TANK"
+        },
+        {
+            "area": 6,
+            "room": 18,
+            "block_x": 29,
+            "block_y": 20,
+            "hidden": false,
+            "original": "MISSILE_TANK"
+        },
+        {
+            "area": 6,
+            "room": 24,
+            "block_x": 29,
+            "block_y": 9,
+            "hidden": false,
+            "original": "MISSILE_TANK"
+        },
+        {
+            "area": 6,
+            "room": 26,
+            "block_x": 5,
+            "block_y": 6,
+            "hidden": false,
+            "original": "ENERGY_TANK"
+        },
+        {
+            "area": 6,
+            "room": 30,
+            "block_x": 9,
+            "block_y": 13,
+            "hidden": true,
+            "original": "MISSILE_TANK"
+        },
+        {
+            "area": 6,
+            "room": 30,
+            "block_x": 19,
+            "block_y": 8,
+            "hidden": false,
+            "original": "MISSILE_TANK"
+        },
+        {
+            "area": 6,
+            "room": 34,
+            "block_x": 14,
+            "block_y": 8,
+            "hidden": false,
+            "original": "ENERGY_TANK"
+        },
+        {
+            "area": 6,
+            "room": 38,
+            "block_x": 45,
+            "block_y": 6,
+            "hidden": false,
+            "original": "ENERGY_TANK"
+        },
+        {
+            "area": 6,
+            "room": 39,
+            "block_x": 10,
+            "block_y": 24,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
+        },
+        {
+            "area": 6,
+            "room": 39,
+            "block_x": 33,
+            "block_y": 10,
+            "hidden": false,
+            "original": "POWER_BOMB_TANK"
         }
     ]
 }

--- a/src/mars_patcher/mf/data/schema.json
+++ b/src/mars_patcher/mf/data/schema.json
@@ -4,20 +4,20 @@
     "description": "A json schema describing the input for patching Metroid Fusion via mars_patcher.",
     "type": "object",
     "properties": {
-        "SeedHash": {
+        "seed_hash": {
             "description": "A seed hash that will be displayed on the file select screen.",
             "type": "string",
             "pattern": "^[0-9A-Z]{8}$"
         },
-        "MusicReplacement": {
+        "music_replacement": {
             "description": "Shuffles the in-game music.",
-            "$ref": "#/$defs/MusicMapping"
+            "$ref": "#/$defs/music_mapping"
         },
-        "Locations": {
+        "locations": {
             "type": "object",
             "description": "Specifies how the item locations in the game should be changed.",
             "properties": {
-                "MajorLocations": {
+                "major_locations": {
                     "type": "array",
                     "description": "Specifies how the major item locations should be changed. A major item location is a location where an item is obtained by defeating a boss or interacting with a device.",
                     "minItems": 23,
@@ -26,27 +26,27 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "Source": {
-                                "$ref": "#/$defs/ValidSources"
+                            "source": {
+                                "$ref": "#/$defs/valid_sources"
                             },
-                            "Item": {
-                                "$ref": "#/$defs/ValidItems"
+                            "item": {
+                                "$ref": "#/$defs/valid_items"
                             },
-                            "ItemMessages": {
-                                "$ref": "#/$defs/ItemMessages"
+                            "item_messages": {
+                                "$ref": "#/$defs/item_messages"
                             },
-                            "Jingle": {
-                                "$ref": "#/$defs/Jingle"
+                            "jingle": {
+                                "$ref": "#/$defs/jingle"
                             }
                         },
                         "required": [
-                            "Source",
-                            "Item",
-                            "Jingle"
+                            "source",
+                            "item",
+                            "jingle"
                         ]
                     }
                 },
-                "MinorLocations": {
+                "minor_locations": {
                     "type": "array",
                     "description": "Specifies how the minor item locations should be changed. A minor item location is a location where an item is obtained by touching a tank block.",
                     "minItems": 103,
@@ -55,119 +55,119 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "Area": {
-                                "$ref": "#/$defs/AreaID",
+                            "area": {
+                                "$ref": "#/$defs/area_id",
                                 "description": "The area ID where this item is located."
                             },
-                            "Room": {
-                                "$ref": "#/$defs/TypeU8",
+                            "room": {
+                                "$ref": "#/$defs/type_u8",
                                 "description": "The room ID where this item is located."
                             },
-                            "BlockX": {
-                                "$ref": "#/$defs/TypeU8",
+                            "block_x": {
+                                "$ref": "#/$defs/type_u8",
                                 "description": "The X-coordinate in the room where this item is located."
                             },
-                            "BlockY": {
-                                "$ref": "#/$defs/TypeU8",
+                            "block_y": {
+                                "$ref": "#/$defs/type_u8",
                                 "description": "The Y-coordinate in the room where this item is located."
                             },
-                            "Item": {
-                                "$ref": "#/$defs/ValidItems"
+                            "item": {
+                                "$ref": "#/$defs/valid_items"
                             },
-                            "ItemSprite": {
-                                "$ref": "#/$defs/ValidItemSprites"
+                            "item_sprite": {
+                                "$ref": "#/$defs/valid_item_sprites"
                             },
-                            "ItemMessages": {
-                                "$ref": "#/$defs/ItemMessages"
+                            "item_messages": {
+                                "$ref": "#/$defs/item_messages"
                             },
-                            "Jingle": {
-                                "$ref": "#/$defs/Jingle"
+                            "jingle": {
+                                "$ref": "#/$defs/jingle"
                             }
                         },
                         "required": [
-                            "Area",
-                            "Room",
-                            "BlockX",
-                            "BlockY",
-                            "Item",
-                            "Jingle"
+                            "area",
+                            "room",
+                            "block_x",
+                            "block_y",
+                            "item",
+                            "jingle"
                         ]
                     }
                 }
             },
             "required": [
-                "MinorLocations",
-                "MajorLocations"
+                "minor_locations",
+                "major_locations"
             ]
         },
-        "RequiredMetroidCount": {
+        "required_metroid_count": {
             "type": "integer",
             "description": "The number of infant Metroids that must be collected to beat the game.",
             "minimum": 0,
             "maximum": 20
         },
-        "StartingLocation": {
+        "starting_location": {
             "type": "object",
             "description": "The location the player should spawn at the start of the game.",
             "properties": {
-                "Area": {
-                    "$ref": "#/$defs/AreaID",
+                "area": {
+                    "$ref": "#/$defs/area_id",
                     "description": "The area ID of the starting location."
                 },
-                "Room": {
-                    "$ref": "#/$defs/TypeU8",
+                "room": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The room ID of the starting location."
                 },
-                "BlockX": {
-                    "$ref": "#/$defs/TypeU8",
+                "block_x": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The X-coordinate in the room where the player should spawn. If the room contains a save station, then this value will not be taken into consideration."
                 },
-                "BlockY": {
-                    "$ref": "#/$defs/TypeU8",
+                "block_y": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The Y-coordinate in the room where the player should spawn. If the room contains a save station, then this value will not be taken into consideration."
                 }
             },
             "required": [
-                "Area",
-                "Room",
-                "BlockX",
-                "BlockY"
+                "area",
+                "room",
+                "block_x",
+                "block_y"
             ]
         },
-        "StartingItems": {
+        "starting_items": {
             "type": "object",
             "properties": {
-                "Energy": {
+                "energy": {
                     "type": "integer",
                     "description": "How much energy the player should start with on a new save file.",
                     "minimum": 1,
                     "maximum": 2099,
                     "default": 99
                 },
-                "Missiles": {
+                "missiles": {
                     "type": "integer",
                     "description": "How many missiles the player should start with on a new save file (the amount unlocked by collecting missile data).",
                     "minimum": 0,
                     "maximum": 999,
                     "default": 10
                 },
-                "PowerBombs": {
+                "power_bombs": {
                     "type": "integer",
                     "description": "How many power bombs the player should start with on a new save file (the amount unlocked by collecting power bomb data).",
                     "minimum": 0,
                     "maximum": 99,
                     "default": 10
                 },
-                "Abilities": {
+                "abilities": {
                     "type": "array",
                     "description": "Which abilities the player should start with on a new save file.",
                     "uniqueItems": true,
                     "items": {
-                        "$ref": "#/$defs/ValidAbilities"
+                        "$ref": "#/$defs/valid_abilities"
                     },
                     "default": []
                 },
-                "SecurityLevels": {
+                "security_levels": {
                     "type": "array",
                     "description": "Which security levels will be unlocked from the start.",
                     "uniqueItems": true,
@@ -185,51 +185,51 @@
                         0
                     ]
                 },
-                "DownloadedMaps": {
+                "downloaded_maps": {
                     "type": "array",
                     "description": "Which area maps will be downloaded from the start.",
                     "uniqueItems": true,
                     "items": {
-                        "$ref": "#/$defs/AreaID"
+                        "$ref": "#/$defs/area_id"
                     },
                     "default": []
                 }
             },
             "default": null
         },
-        "TankIncrements": {
+        "tank_increments": {
             "type": "object",
             "description": "How much ammo/health tanks provide when collected.",
             "properties": {
-                "MissileTank": {
+                "missile_tank": {
                     "type": "integer",
                     "description": "How much ammo missile tanks provide when collected.",
                     "minimum": -1000,
                     "maximum": 1000,
                     "default": 5
                 },
-                "EnergyTank": {
+                "energy_tank": {
                     "type": "integer",
                     "description": "How much health energy tanks provide when collected.",
                     "minimum": -2100,
                     "maximum": 2100,
                     "default": 100
                 },
-                "PowerBombTank": {
+                "power_bomb_tank": {
                     "type": "integer",
                     "description": "How much ammo power bomb tanks provide when collected.",
                     "minimum": -100,
                     "maximum": 100,
                     "default": 2
                 },
-                "MissileData": {
+                "missile_data": {
                     "type": "integer",
                     "description": "How much ammo Missile Launcher Data provides when collected.",
                     "minimum": 0,
                     "maximum": 1000,
                     "default": 10
                 },
-                "PowerBombData": {
+                "power_bomb_data": {
                     "type": "integer",
                     "description": "How much ammo Power Bomb Data provides when collected.",
                     "minimum": 0,
@@ -238,129 +238,129 @@
                 }
             },
             "required": [
-                "MissileTank",
-                "EnergyTank",
-                "PowerBombTank"
+                "missile_tank",
+                "energy_tank",
+                "power_bomb_tank"
             ],
             "default": null
         },
-        "ElevatorConnections": {
+        "elevator_connections": {
             "type": "object",
             "description": "Defines the elevator that each elevator connects to.",
             "properties": {
-                "ElevatorTops": {
+                "elevator_tops": {
                     "type": "object",
                     "description": "Defines the bottom elevator that each top elevator connects to.",
                     "propertyNames": {
-                        "$ref": "#/$defs/ValidElevatorTops"
+                        "$ref": "#/$defs/valid_elevator_tops"
                     },
                     "additionalProperties": {
-                        "$ref": "#/$defs/ValidElevatorBottoms"
+                        "$ref": "#/$defs/valid_elevator_bottoms"
                     },
                     "minProperties": 10
                 },
-                "ElevatorBottoms": {
+                "elevator_bottoms": {
                     "type": "object",
                     "description": "Defines the top elevator that each bottom elevator connects to.",
                     "propertyNames": {
-                        "$ref": "#/$defs/ValidElevatorBottoms"
+                        "$ref": "#/$defs/valid_elevator_bottoms"
                     },
                     "additionalProperties": {
-                        "$ref": "#/$defs/ValidElevatorTops"
+                        "$ref": "#/$defs/valid_elevator_tops"
                     },
                     "minProperties": 10
                 }
             },
             "required": [
-                "ElevatorTops",
-                "ElevatorBottoms"
+                "elevator_tops",
+                "elevator_bottoms"
             ]
         },
-        "SectorShortcuts": {
+        "sector_shortcuts": {
             "type": "object",
             "description": "Defines the sector that each sector shortcut connects to.",
             "properties": {
-                "LeftAreas": {
-                    "$ref": "#/$defs/ShortcutSectorList",
+                "left_areas": {
+                    "$ref": "#/$defs/shortcut_sector_list",
                     "description": "Destination areas on the left side of sectors."
                 },
-                "RightAreas": {
-                    "$ref": "#/$defs/ShortcutSectorList",
+                "right_areas": {
+                    "$ref": "#/$defs/shortcut_sector_list",
                     "description": "Destination areas on the right side of sectors"
                 }
             },
             "required": [
-                "LeftAreas",
-                "RightAreas"
+                "left_areas",
+                "right_areas"
             ]
         },
-        "DoorLocks": {
+        "door_locks": {
             "type": "array",
             "description": "List of all lockable doors and their lock type.",
             "items": {
                 "type": "object",
                 "properties": {
-                    "Area": {
-                        "$ref": "#/$defs/AreaID",
+                    "area": {
+                        "$ref": "#/$defs/area_id",
                         "description": "The area ID where this door is located."
                     },
-                    "Door": {
-                        "$ref": "#/$defs/TypeU8",
+                    "door": {
+                        "$ref": "#/$defs/type_u8",
                         "description": "The door ID of this door."
                     },
-                    "LockType": {
+                    "lock_type": {
                         "type": "string",
                         "description": "The type of cover on the hatch.",
                         "enum": [
-                            "Open",
-                            "Level0",
-                            "Level1",
-                            "Level2",
-                            "Level3",
-                            "Level4",
-                            "Locked"
+                            "OPEN",
+                            "LEVEL_0",
+                            "LEVEL_1",
+                            "LEVEL_2",
+                            "LEVEL_3",
+                            "LEVEL_4",
+                            "LOCKED"
                         ]
                     }
                 },
                 "required": [
-                    "Area",
-                    "Door",
-                    "LockType"
+                    "area",
+                    "door",
+                    "lock_type"
                 ]
             }
         },
-        "Palettes": {
+        "palettes": {
             "type": "object",
             "description": "Properties for randomized in-game palettes.",
             "properties": {
-                "Seed": {
-                    "$ref": "#/$defs/Seed",
+                "seed": {
+                    "$ref": "#/$defs/seed",
                     "description": "A number used to initialize the random number generator for palettes. If not specified, the patcher will randomly generate one.",
                     "default": null
                 },
-                "Randomize": {
+                "randomize": {
                     "type": "object",
                     "description": "What kind of palettes should be randomized.",
                     "propertyNames": {
                         "type": "string",
                         "enum": [
-                            "Tilesets",
-                            "Enemies",
-                            "Samus",
-                            "Beams"
+                            "TILESETS",
+                            "ENEMIES",
+                            "SAMUS",
+                            "BEAMS"
                         ]
                     },
                     "additionalProperties": {
                         "type": "object",
                         "description": "The range to use for rotating palette hues.",
                         "properties": {
-                            "HueMin": {
-                                "$ref": "#/$defs/HueRotation",
+                            "hue_min": {
+                                "$ref": "#/$defs/hue_rotation",
                                 "description": "The minimum value to use for rotating palette hues. If not specified, the patcher will randomly generate one.",
                                 "default": null
                             },
-                            "HueMax": {
-                                "$ref": "#/$defs/HueRotation",
+                            "hue_max": {
+                                "$ref": "#/$defs/hue_rotation",
                                 "description": "The maximum value to use for rotating palette hues. If not specified, the patcher will randomly generate one.",
                                 "default": null
                             }
@@ -368,16 +368,16 @@
                         "additionalProperties": false
                     }
                 },
-                "ColorSpace": {
+                "color_space": {
                     "type": "string",
                     "description": "The color space to use for rotating palette hues.",
                     "enum": [
                         "HSV",
-                        "Oklab"
+                        "OKLAB"
                     ],
-                    "default": "Oklab"
+                    "default": "OKLAB"
                 },
-                "Symmetric": {
+                "symmetric": {
                     "type": "boolean",
                     "description": "Randomly rotates hues in the positive or negative direction true.",
                     "default": true
@@ -385,79 +385,79 @@
             },
             "additionalProperties": false,
             "required": [
-                "Randomize"
+                "randomize"
             ],
             "default": null
         },
-        "NavigationText": {
+        "navigation_text": {
             "type": "object",
             "description": "Specifies text to be displayed at navigation rooms and the ship.",
             "propertyNames": {
-                "$ref": "#/$defs/ValidLanguages"
+                "$ref": "#/$defs/valid_languages"
             },
             "additionalProperties": {
                 "type": "object",
                 "description": "Specifies text for a specific language.",
                 "properties": {
-                    "NavigationTerminals": {
+                    "navigation_terminals": {
                         "type": "object",
                         "description": "Assigns each navigation room a specific text.",
                         "properties": {
-                            "MainDeckWest": {
+                            "MAIN_DECK_WEST": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the west Navigation Terminal in Main Deck."
                             },
-                            "MainDeckEast": {
+                            "MAIN_DECK_EAST": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the east Navigation Terminal in Main Deck."
                             },
-                            "OperationsDeck": {
+                            "OPERATIONS_DECK": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in Operations Deck."
                             },
-                            "Sector1Entrance": {
+                            "SECTOR_1_ENTRANCE": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in Sector 1."
                             },
-                            "Sector2Entrance": {
+                            "SECTOR_2_ENTRANCE": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in Sector 2."
                             },
-                            "Sector3Entrance": {
+                            "SECTOR_3_ENTRANCE": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in Sector 3."
                             },
-                            "Sector4Entrance": {
+                            "SECTOR_4_ENTRANCE": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in Sector 4."
                             },
-                            "Sector5Entrance": {
+                            "SECTOR_5_ENTRANCE": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in Sector 5."
                             },
-                            "Sector6Entrance": {
+                            "SECTOR_6_ENTRANCE": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in Sector 6."
                             },
-                            "AuxiliaryPower": {
+                            "AUXILIARY_POWER": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal near the Auxiliary Power Station."
                             },
-                            "RestrictedLabs": {
+                            "RESTRICTED_LABS": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the Navigation Terminal in the Restricted Labs."
                             }
                         }
                     },
-                    "ShipText": {
+                    "ship_text": {
                         "type": "object",
                         "description": "Assigns the ship specific text.",
                         "properties": {
-                            "InitialText": {
+                            "initial_text": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the initial ship communication."
                             },
-                            "ConfirmText": {
+                            "confirm_text": {
                                 "type": "string",
                                 "description": "Specifies what text should appear at the ship after confirming 'No' on subsequent ship communications."
                             }
@@ -468,18 +468,18 @@
             },
             "default": null
         },
-        "TitleText": {
+        "title_text": {
             "type": "array",
             "description": "Lines of ASCII text to write to the title screen.",
             "items": {
                 "type": "object",
                 "properties": {
-                    "Text": {
+                    "text": {
                         "type": "string",
                         "description": "The ASCII text for this line",
                         "pattern": "^[ -~]{0,30}$"
                     },
-                    "LineNum": {
+                    "line_num": {
                         "type": "integer",
                         "minimum": 0,
                         "maximum": 20
@@ -488,155 +488,155 @@
             },
             "default": null
         },
-        "CreditsText": {
+        "credits_text": {
             "type": "array",
             "description": "Lines of text to insert into the credits.",
             "items": {
                 "type": "object",
                 "properties": {
-                    "LineType": {
+                    "line_type": {
                         "type": "string",
                         "description": "The color and line height of the text (or blank).",
                         "enum": [
-                            "Blank",
-                            "Blue",
-                            "Red",
-                            "White1",
-                            "White2"
+                            "BLANK",
+                            "BLUE",
+                            "RED",
+                            "WHITE",
+                            "WHITE_BIG"
                         ]
                     },
-                    "Text": {
+                    "text": {
                         "type": "string",
                         "description": "The ASCII text for this line.",
                         "pattern": "^[ -~]{0,34}$"
                     },
-                    "BlankLines": {
-                        "$ref": "#/$defs/TypeU8",
+                    "blank_lines": {
+                        "$ref": "#/$defs/type_u8",
                         "description": "Inserts the provided number of blank lines after the text line.",
                         "default": 0
                     },
-                    "Centered": {
+                    "centered": {
                         "type": "boolean",
                         "description": "Centers the text horizontally when true.",
                         "default": true
                     }
                 },
                 "required": [
-                    "LineType"
+                    "line_type"
                 ]
             }
         },
-        "NavStationLocks": {
+        "nav_station_locks": {
             "type": "object",
             "description": "Sets the required Security Levels for accessing Navigation Terminals.",
             "propertyNames": {
                 "type": "string",
                 "enum": [
-                    "MainDeckWest",
-                    "MainDeckEast",
-                    "OperationsDeck",
-                    "RestrictedLabs",
-                    "AuxiliaryPower",
-                    "Sector1Entrance",
-                    "Sector2Entrance",
-                    "Sector3Entrance",
-                    "Sector4Entrance",
-                    "Sector5Entrance",
-                    "Sector6Entrance"
+                    "MAIN_DECK_WEST",
+                    "MAIN_DECK_EAST",
+                    "OPERATIONS_DECK",
+                    "RESTRICTED_LABS",
+                    "AUXILIARY_POWER",
+                    "SECTOR_1_ENTRANCE",
+                    "SECTOR_2_ENTRANCE",
+                    "SECTOR_3_ENTRANCE",
+                    "SECTOR_4_ENTRANCE",
+                    "SECTOR_5_ENTRANCE",
+                    "SECTOR_6_ENTRANCE"
                 ]
             },
             "additionalProperties": {
-                "$ref": "#/$defs/HintLocks",
+                "$ref": "#/$defs/hint_locks",
                 "additionalProperties": false
             }
         },
-        "DisableDemos": {
+        "disable_demos": {
             "type": "boolean",
             "description": "Disables title screen demos when true.",
             "default": false
         },
-        "InstantUnmorph": {
+        "instant_unmorph": {
             "type": "boolean",
             "description": "When true, enables instant unmorphing via the SELECT button.",
             "default": false
         },
-        "NerfGerons": {
+        "nerf_gerons": {
             "type": "boolean",
             "description": "When true, changes the Geron weaknesses to only be weak to their 'intended' values.",
             "default": false
         },
-        "UseAlternativeHudHealthLayout": {
+        "use_alternative_hud_health_layout": {
             "type": "boolean",
             "description": "When true, changes the HUD health layout to display 'currentHP/totalHP'.",
             "default": false
         },
-        "SkipDoorTransitions": {
+        "skip_door_transitions": {
             "type": "boolean",
             "description": "Makes all door transitions instant when true.",
             "default": false
         },
-        "StereoDefault": {
+        "stereo_default": {
             "type": "boolean",
             "description": "Forces stereo sound by default when true.",
             "default": true
         },
-        "DisableMusic": {
+        "disable_music": {
             "type": "boolean",
             "description": "Disables all music tracks when true.",
             "default": false
         },
-        "DisableSoundEffects": {
+        "disable_sound_effects": {
             "type": "boolean",
             "description": "Disables all sound effects when true.",
             "default": false
         },
-        "EnvironmentalDamage": {
+        "environmental_damage": {
             "type": "object",
             "properties": {
-                "Lava": {
-                    "$ref": "#/$defs/TypeU8",
+                "lava": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The amount of damage per second taken while submerged in lava.",
                     "default": 20
                 },
-                "Acid": {
-                    "$ref": "#/$defs/TypeU8",
+                "acid": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The amount of damage per second taken while submerged in acid.",
                     "default": 60
                 },
-                "Heat": {
-                    "$ref": "#/$defs/TypeU8",
+                "heat": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The amount of damage per second taken while in a heated environment.",
                     "default": 6
                 },
-                "Cold": {
-                    "$ref": "#/$defs/TypeU8",
+                "cold": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The amount of damage per second taken while in a cold environment.",
                     "default": 15
                 },
-                "Subzero": {
-                    "$ref": "#/$defs/TypeU8",
+                "subzero": {
+                    "$ref": "#/$defs/type_u8",
                     "description": "The amount of damage per second taken while in Sub-Zero Containment. Currently unused, will always use Cold.",
                     "default": 6
                 }
             },
-            "required": ["Lava", "Acid", "Heat", "Cold", "Subzero"]
+            "required": ["lava", "acid", "heat", "cold", "subzero"]
         },
-        "MissileLimit": {
-            "$ref": "#/$defs/TypeU8",
+        "missile_limit": {
+            "$ref": "#/$defs/type_u8",
             "description": "Changes how many missiles can be on-screen at a time. The vanilla game has it set to 2, the randomizer changes it to 3 by default. Zero Mission uses 4.",
             "default": 3
         },
-        "UnexploredMap": {
+        "unexplored_map": {
             "type": "boolean",
             "description": "When enabled, starts you with a map where all unexplored items and non-visited tiles have a gray background. This is different from the downloaded map stations where there, the full tile is gray.",
             "default": false
         },
-        "LevelEdits": {
+        "level_edits": {
             "type": "object",
             "description": "Specifies room edits that should be done. These will be applied last.",
             "propertyNames": {
                 "description": "Specifies the Area ID.",
-                "$ref": "#/$defs/AreaIDKey"
+                "$ref": "#/$defs/area_id_key"
             },
             "additionalProperties": {
                 "type": "object",
@@ -645,17 +645,17 @@
                         "type": "object",
                         "description": "Specifies the Room ID.",
                         "properties": {
-                            "BG1": {
+                            "bg1": {
                                 "description": "The BG1 layer that should be edited.",
-                                "$ref": "#/$defs/BlockLayer"
+                                "$ref": "#/$defs/block_layer"
                             },
-                            "BG2": {
+                            "bg2": {
                                 "description": "The BG2 layer that should be edited.",
-                                "$ref": "#/$defs/BlockLayer"
+                                "$ref": "#/$defs/block_layer"
                             },
-                            "Clipdata": {
+                            "clipdata": {
                                 "description": "The Clipdata layer that should be edited.",
-                                "$ref": "#/$defs/BlockLayer"
+                                "$ref": "#/$defs/block_layer"
                             }
                         },
                         "additionalProperties": false
@@ -663,40 +663,40 @@
                 }
             }
         },
-        "MinimapEdits": {
+        "minimap_edits": {
             "type": "object",
             "description": "Specifies minimap edits that should be done.",
             "propertyNames": {
                 "description": "Specifies the Area ID.",
-                "$ref": "#/$defs/MinimapIDKey"
+                "$ref": "#/$defs/minimap_id_key"
             },
             "additionalProperties": {
                 "type": "array",
                 "items": {
                     "type": "object",
                     "properties": {
-                        "X": {
-                            "$ref": "#/$defs/TypeU5",
+                        "x": {
+                            "$ref": "#/$defs/type_u5",
                             "description": "The X position in the minimap that should get edited."
                         },
-                        "Y": {
-                            "$ref": "#/$defs/TypeU5",
+                        "y": {
+                            "$ref": "#/$defs/type_u5",
                             "description": "The Y position in the minimap that should get edited."
                         },
-                        "Tile": {
-                            "$ref": "#/$defs/TypeU10",
+                        "tile": {
+                            "$ref": "#/$defs/type_u10",
                             "description": "The tile value that should be used to edit the minimap."
                         },
-                        "Palette": {
-                            "$ref": "#/$defs/TypeU4",
+                        "palette": {
+                            "$ref": "#/$defs/type_u4",
                             "description": "The palette row to use for the tile."
                         },
-                        "HFlip": {
+                        "h_flip": {
                             "type": "boolean",
                             "default": false,
                             "description": "Whether the tile should be horizontally flipped or not."
                         },
-                        "VFlip": {
+                        "v_flip": {
                             "type": "boolean",
                             "default": false,
                             "description": "Whether the tile should be vertically flipped or not."
@@ -705,82 +705,82 @@
                 }
             }
         },
-        "HideDoorsOnMinimap": {
+        "hide_doors_on_minimap": {
             "type": "boolean",
             "description": "When enabled, hides doors on the minimap. This is automatically enabled when the 'DoorLocks' field is provided.",
             "default": false
         },
-        "RoomNames": {
+        "room_names": {
             "type": "array",
             "description": "Specifies a name to be displayed when the A Button is pressed on the pause menu.",
             "uniqueItems": true,
             "items": {
                 "type": "object",
                 "properties": {
-                    "Area": {
-                        "$ref": "#/$defs/AreaID",
+                    "area": {
+                        "$ref": "#/$defs/area_id",
                         "description": "The area ID where this room is located."
                     },
-                    "Room": {
-                        "$ref": "#/$defs/TypeU8",
+                    "room": {
+                        "$ref": "#/$defs/type_u8",
                         "description": "The room ID."
                     },
-                    "Name": {
+                    "name": {
                         "type": "string",
                         "description": "Specifies what text should appear for this room. Two lines are available, with an absolute maximum of 56 characters per line, if all characters used are small. Text will auto-wrap if the next word doesn't fit on the line. If the text is too long, it will be truncated. Use \n to force a line break. If not provided, will display 'Room name not provided'.",
                         "maxLength": 112
                     }
                 },
                 "required": [
-                    "Area",
-                    "Room",
-                    "Name"
+                    "area",
+                    "room",
+                    "name"
                 ]
             }
         },
-        "RevealHiddenTiles": {
+        "reveal_hidden_tiles": {
             "type": "boolean",
             "description": "When enabled, reveals normally hidden blocks that are breakable by upgrades. Hidden pickup tanks are not revealed regardless of this setting.",
             "default": false
         }
     },
     "required": [
-        "SeedHash",
-        "Locations",
-        "RequiredMetroidCount"
+        "seed_hash",
+        "locations",
+        "required_metroid_count"
     ],
     "$defs": {
-        "Seed": {
+        "seed": {
             "type": "integer",
             "minimum": 0,
             "maximum": 2147483647
         },
-        "TypeU4": {
+        "type_u4": {
             "type": "integer",
             "minimum": 0,
             "maximum": 15
         },
-        "TypeU5": {
+        "type_u5": {
             "type": "integer",
             "minimum": 0,
             "maximum": 31
         },
-        "TypeU8": {
+        "type_u8": {
             "type": "integer",
             "minimum": 0,
             "maximum": 255
         },
-        "TypeU10": {
+        "type_u10": {
             "type": "integer",
             "minimum": 0,
             "maximum": 1023
         },
-        "AreaID": {
+        "area_id": {
             "type": "integer",
             "minimum": 0,
             "maximum": 6
         },
-        "AreaIDKey": {
+        "area_id_key": {
             "type": "string",
             "enum": [
                 "0",
@@ -792,7 +792,7 @@
                 "6"
             ]
         },
-        "MinimapIDKey": {
+        "minimap_id_key": {
             "type": "string",
             "enum": [
                 "0",
@@ -808,201 +808,201 @@
                 "10"
             ]
         },
-        "SectorID": {
+        "sector_id": {
             "type": "integer",
             "minimum": 1,
             "maximum": 6
         },
-        "ShortcutSectorList": {
+        "shortcut_sector_list": {
             "type": "array",
             "items": {
-                "$ref": "#/$defs/SectorID"
+                "$ref": "#/$defs/sector_id"
             },
             "minItems": 6,
             "maxItems": 6
         },
-        "HueRotation": {
+        "hue_rotation": {
             "type": "integer",
             "minimum": 0,
             "maximum": 360
         },
-        "ValidSources": {
+        "valid_sources": {
             "type": "string",
             "description": "Valid major locations.",
             "enum": [
-                "MainDeckData",
-                "Arachnus",
-                "ChargeCoreX",
-                "Level1",
-                "TroData",
-                "Zazabi",
-                "Serris",
-                "Level2",
-                "PyrData",
-                "MegaX",
-                "Level3",
-                "ArcData1",
-                "WideCoreX",
-                "ArcData2",
-                "Yakuza",
-                "Nettori",
-                "Nightmare",
-                "Level4",
-                "AqaData",
-                "WaveCoreX",
-                "Ridley",
-                "Boiler",
-                "Animals",
-                "AuxiliaryPower"
+                "MAIN_DECK_DATA",
+                "ARACHNUS",
+                "CHARGE_CORE_X",
+                "LEVEL_1",
+                "TRO_DATA",
+                "ZAZABI",
+                "SERRIS",
+                "LEVEL_2",
+                "PYR_DATA",
+                "MEGA_X",
+                "LEVEL_3",
+                "ARC_DATA_1",
+                "WIDE_CORE_X",
+                "ARC_DATA_2",
+                "YAKUZA",
+                "NETTORI",
+                "NIGHTMARE",
+                "LEVEL_4",
+                "AQA_DATA",
+                "WAVE_CORE_X",
+                "RIDLEY",
+                "BOILER",
+                "ANIMALS",
+                "AUXILIARY_POWER"
             ]
         },
-        "ValidItems": {
+        "valid_items": {
             "type": "string",
             "description": "Valid items for shuffling.",
             "enum": [
-                "None",
-                "Level0",
-                "Missiles",
-                "MorphBall",
-                "ChargeBeam",
-                "Level1",
-                "Bombs",
-                "HiJump",
-                "SpeedBooster",
-                "Level2",
-                "SuperMissiles",
-                "VariaSuit",
-                "Level3",
-                "IceMissiles",
-                "WideBeam",
-                "PowerBombs",
-                "SpaceJump",
-                "PlasmaBeam",
-                "GravitySuit",
-                "Level4",
-                "DiffusionMissiles",
-                "WaveBeam",
-                "ScrewAttack",
-                "IceBeam",
-                "MissileTank",
-                "EnergyTank",
-                "PowerBombTank",
-                "IceTrap",
-                "InfantMetroid"
+                "NONE",
+                "LEVEL_0",
+                "MISSILES",
+                "MORPH_BALL",
+                "CHARGE_BEAM",
+                "LEVEL_1",
+                "BOMBS",
+                "HI_JUMP",
+                "SPEED_BOOSTER",
+                "LEVEL_2",
+                "SUPER_MISSILES",
+                "VARIA_SUIT",
+                "LEVEL_3",
+                "ICE_MISSILES",
+                "WIDE_BEAM",
+                "POWER_BOMBS",
+                "SPACE_JUMP",
+                "PLASMA_BEAM",
+                "GRAVITY_SUIT",
+                "LEVEL_4",
+                "DIFFUSION_MISSILES",
+                "WAVE_BEAM",
+                "SCREW_ATTACK",
+                "ICE_BEAM",
+                "MISSILE_TANK",
+                "ENERGY_TANK",
+                "POWER_BOMB_TANK",
+                "ICE_TRAP",
+                "INFANT_METROID"
             ]
         },
-        "ValidItemSprites": {
+        "valid_item_sprites": {
             "type": "string",
             "description": "Valid graphics for minor location items.",
             "enum": [
-                "Empty",
-                "Missiles",
-                "Level0",
-                "MorphBall",
-                "ChargeBeam",
-                "Level1",
-                "Bombs",
-                "HiJump",
-                "SpeedBooster",
-                "Level2",
-                "SuperMissiles",
-                "VariaSuit",
-                "Level3",
-                "IceMissiles",
-                "WideBeam",
-                "PowerBombs",
-                "SpaceJump",
-                "PlasmaBeam",
-                "GravitySuit",
-                "Level4",
-                "DiffusionMissiles",
-                "WaveBeam",
-                "ScrewAttack",
-                "IceBeam",
-                "MissileTank",
-                "EnergyTank",
-                "PowerBombTank",
-                "Anonymous",
-                "ShinyMissileTank",
-                "ShinyPowerBombTank",
-                "InfantMetroid",
-                "SamusHead",
-                "WalljumpBoots",
-                "Randovania",
-                "ArchipelagoColor",
-                "ArchipelagoMonochrome"
+                "EMPTY",
+                "MISSILES",
+                "LEVEL_0",
+                "MORPH_BALL",
+                "CHARGE_BEAM",
+                "LEVEL_1",
+                "BOMBS",
+                "HI_JUMP",
+                "SPEED_BOOSTER",
+                "LEVEL_2",
+                "SUPER_MISSILES",
+                "VARIA_SUIT",
+                "LEVEL_3",
+                "ICE_MISSILES",
+                "WIDE_BEAM",
+                "POWER_BOMBS",
+                "SPACE_JUMP",
+                "PLASMA_BEAM",
+                "GRAVITY_SUIT",
+                "LEVEL_4",
+                "DIFFUSION_MISSILES",
+                "WAVE_BEAM",
+                "SCREW_ATTACK",
+                "ICE_BEAM",
+                "MISSILE_TANK",
+                "ENERGY_TANK",
+                "POWER_BOMB_TANK",
+                "ANONYMOUS",
+                "SHINY_MISSILE_TANK",
+                "SHINY_POWER_BOMB_TANK",
+                "INFANT_METROID",
+                "SAMUS_HEAD",
+                "WALLJUMP_BOOTS",
+                "RANDOVANIA",
+                "ARCHIPELAGO_COLOR",
+                "ARCHIPELAGO_MONOCHROME"
             ]
         },
-        "ValidAbilities": {
+        "valid_abilities": {
             "type": "string",
             "description": "Valid abilities to start with.",
             "enum": [
-                "Missiles",
-                "MorphBall",
-                "ChargeBeam",
-                "Bombs",
-                "HiJump",
-                "SpeedBooster",
-                "SuperMissiles",
-                "VariaSuit",
-                "IceMissiles",
-                "WideBeam",
-                "PowerBombs",
-                "SpaceJump",
-                "PlasmaBeam",
-                "GravitySuit",
-                "DiffusionMissiles",
-                "WaveBeam",
-                "ScrewAttack",
-                "IceBeam"
+                "MISSILES",
+                "MORPH_BALL",
+                "CHARGE_BEAM",
+                "BOMBS",
+                "HI_JUMP",
+                "SPEED_BOOSTER",
+                "SUPER_MISSILES",
+                "VARIA_SUIT",
+                "ICE_MISSILES",
+                "WIDE_BEAM",
+                "POWER_BOMBS",
+                "SPACE_JUMP",
+                "PLASMA_BEAM",
+                "GRAVITY_SUIT",
+                "DIFFUSION_MISSILES",
+                "WAVE_BEAM",
+                "SCREW_ATTACK",
+                "ICE_BEAM"
             ]
         },
-        "ValidElevatorTops": {
+        "valid_elevator_tops": {
             "type": "string",
             "description": "Valid elevators at the top of elevator shafts.",
             "enum": [
-                "OperationsDeckTop",
-                "MainHubToSector1",
-                "MainHubToSector2",
-                "MainHubToSector3",
-                "MainHubToSector4",
-                "MainHubToSector5",
-                "MainHubToSector6",
-                "MainHubTop",
-                "HabitationDeckTop",
-                "Sector1ToRestrictedLab"
+                "OPERATIONS_DECK_TOP",
+                "MAIN_HUB_TO_SECTOR_1",
+                "MAIN_HUB_TO_SECTOR_2",
+                "MAIN_HUB_TO_SECTOR_3",
+                "MAIN_HUB_TO_SECTOR_4",
+                "MAIN_HUB_TO_SECTOR_5",
+                "MAIN_HUB_TO_SECTOR_6",
+                "MAIN_HUB_TOP",
+                "HABITATION_DECK_TOP",
+                "SECTOR_1_TO_RESTRICTED_LAB"
             ]
         },
-        "ValidElevatorBottoms": {
+        "valid_elevator_bottoms": {
             "type": "string",
             "description": "Valid elevators at the bottom of elevator shafts.",
             "enum": [
-                "OperationsDeckBottom",
-                "MainHubBottom",
-                "RestrictedLabToSector1",
-                "HabitationDeckBottom",
-                "Sector1ToMainHub",
-                "Sector2ToMainHub",
-                "Sector3ToMainHub",
-                "Sector4ToMainHub",
-                "Sector5ToMainHub",
-                "Sector6ToMainHub"
+                "OPERATIONS_DECK_BOTTOM",
+                "MAIN_HUB_BOTTOM",
+                "RESTRICTED_LAB_TO_SECTOR_1",
+                "HABITATION_DECK_BOTTOM",
+                "SECTOR_1_TO_MAIN_HUB",
+                "SECTOR_2_TO_MAIN_HUB",
+                "SECTOR_3_TO_MAIN_HUB",
+                "SECTOR_4_TO_MAIN_HUB",
+                "SECTOR_5_TO_MAIN_HUB",
+                "SECTOR_6_TO_MAIN_HUB"
             ]
         },
-        "ValidLanguages": {
+        "valid_languages": {
             "type": "string",
             "description": "Valid languages supported by the game.",
             "enum": [
-                "JapaneseKanji",
-                "JapaneseHiragana",
-                "English",
-                "German",
-                "French",
-                "Italian",
-                "Spanish"
+                "JAPANESE_KANJI",
+                "JAPANESE_HIRAGANA",
+                "ENGLISH",
+                "GERMAN",
+                "FRENCH",
+                "ITALIAN",
+                "SPANISH"
             ]
         },
-        "ValidMusicTracks": {
+        "valid_music_tracks": {
             "type": "string",
             "description": "Valid music tracks supported by the game.",
             "enum": [
@@ -1067,70 +1067,70 @@
                 "UNEASE"
             ]
         },
-        "MusicMapping": {
+        "music_mapping": {
             "description": "Maps music tracks to each other",
             "type": "object",
             "propertyNames": {
-                "$ref": "#/$defs/ValidMusicTracks"
+                "$ref": "#/$defs/valid_music_tracks"
             },
             "additionalProperties": {
-                "$ref": "#/$defs/ValidMusicTracks"
+                "$ref": "#/$defs/valid_music_tracks"
             }
         },
-        "MessageLanguages": {
+        "message_languages": {
             "type": "object",
             "propertyNames": {
-                "$ref": "#/$defs/ValidLanguages"
+                "$ref": "#/$defs/valid_languages"
             },
             "required": [
-                "English"
+                "ENGLISH"
             ],
             "additionalProperties": {
                 "type": "string",
                 "description": "Specifies what text should appear for a 2 line message. Text will auto-wrap if the next word doesn't fit on the line. If the text is too long, it will be truncated. Use \n to force a line break. If not provided, a message based on the Item will be shown. If a language is not provided, it will use the provided English message."
             }
         },
-        "ItemMessages": {
+        "item_messages": {
             "type": "object",
             "properties": {
-                "Kind": {
-                    "$ref": "#/$defs/ItemMessagesKind"
+                "kind": {
+                    "$ref": "#/$defs/item_messages_kind"
                 }
             },
             "required": [
-                "Kind"
+                "kind"
             ],
             "if": {
                 "properties": {
-                    "Kind": {
-                        "const": "CustomMessage"
+                    "kind": {
+                        "const": "CUSTOM_MESSAGE"
                     }
                 }
             },
             "then": {
                 "properties": {
-                    "Kind": {
-                        "$ref": "#/$defs/ItemMessagesKind"
+                    "kind": {
+                        "$ref": "#/$defs/item_messages_kind"
                     },
-                    "Languages": {
-                        "$ref": "#/$defs/MessageLanguages"
+                    "languages": {
+                        "$ref": "#/$defs/message_languages"
                     },
-                    "Centered": {
+                    "centered": {
                         "type": "boolean",
                         "default": true
                     }
                 },
                 "required": [
-                    "Languages"
+                    "languages"
                 ],
                 "additionalProperties": false
             },
             "else": {
                 "properties": {
-                    "Kind": {
-                        "$ref": "#/$defs/ItemMessagesKind"
+                    "kind": {
+                        "$ref": "#/$defs/item_messages_kind"
                     },
-                    "MessageID": {
+                    "message_id": {
                         "type": "integer",
                         "minimum": 0,
                         "maximum": 56,
@@ -1138,47 +1138,47 @@
                     }
                 },
                 "required": [
-                    "MessageID"
+                    "message_id"
                 ],
                 "additionalProperties": false
             }
         },
-        "ItemMessagesKind": {
+        "item_messages_kind": {
             "type": "string",
             "enum": [
-                "CustomMessage",
-                "MessageID"
+                "CUSTOM_MESSAGE",
+                "MESSAGE_ID"
             ]
         },
-        "Jingle": {
+        "jingle": {
             "type": "string",
             "enum": [
-                "Minor",
-                "Major"
+                "MINOR",
+                "MAJOR"
             ]
         },
-        "BlockLayer": {
+        "block_layer": {
             "type": "array",
             "uniqueItems": true,
             "items": {
                 "type": "object",
                 "properties": {
-                    "X": {
-                        "$ref": "#/$defs/TypeU8",
+                    "x": {
+                        "$ref": "#/$defs/type_u8",
                         "description": "The X position in the room that should get edited."
                     },
-                    "Y": {
-                        "$ref": "#/$defs/TypeU8",
+                    "y": {
+                        "$ref": "#/$defs/type_u8",
                         "description": "The Y position in the room that should get edited."
                     },
-                    "Value": {
-                        "$ref": "#/$defs/TypeU10",
+                    "value": {
+                        "$ref": "#/$defs/type_u10",
                         "description": "The value that should be used to edit the room. For backgrounds, this is calculated via `((Row-1) * ColumnsInTileset) + (Column-1)`."
                     }
                 }
             }
         },
-        "HintLocks": {
+        "hint_locks": {
             "type": "string",
             "enum": [
                 "OPEN",

--- a/src/mars_patcher/mf/door_locks.py
+++ b/src/mars_patcher/mf/door_locks.py
@@ -7,7 +7,7 @@ from mars_patcher.common_types import AreaId, AreaRoomPair
 from mars_patcher.constants.door_types import DoorType
 from mars_patcher.constants.game_data import area_doors_ptrs, minimap_graphics
 from mars_patcher.constants.minimap_tiles import ColoredDoor, Content, Edge
-from mars_patcher.mf.auto_generated_types import MarsschemamfDoorlocksItem
+from mars_patcher.mf.auto_generated_types import MarsschemamfDoorLocksItem
 from mars_patcher.mf.constants.game_data import hatch_lock_event_count, hatch_lock_events
 from mars_patcher.mf.constants.minimap_tiles import (
     ALL_DOOR_TILE_IDS,
@@ -30,16 +30,6 @@ class HatchLock(Enum):
     LEVEL_4 = 5
     LOCKED = 6
 
-
-HATCH_LOCK_ENUMS = {
-    "Open": HatchLock.OPEN,
-    "Level0": HatchLock.LEVEL_0,
-    "Level1": HatchLock.LEVEL_1,
-    "Level2": HatchLock.LEVEL_2,
-    "Level3": HatchLock.LEVEL_3,
-    "Level4": HatchLock.LEVEL_4,
-    "Locked": HatchLock.LOCKED,
-}
 
 BG1_VALUES = {
     HatchLock.OPEN: 0x4,
@@ -98,7 +88,7 @@ class MinimapLockChanges(TypedDict, total=False):
 # TODO:
 # - Optimize by only loading rooms that contain doors to modify
 # - Split into more than one function for readability
-def set_door_locks(rom: Rom, data: list[MarsschemamfDoorlocksItem]) -> None:
+def set_door_locks(rom: Rom, data: list[MarsschemamfDoorLocksItem]) -> None:
     door_locks = parse_door_lock_data(data)
 
     # Go through all doors in game in order
@@ -262,12 +252,12 @@ def set_door_locks(rom: Rom, data: list[MarsschemamfDoorlocksItem]) -> None:
     change_minimap_tiles(rom, minimap_changes)
 
 
-def parse_door_lock_data(data: list[MarsschemamfDoorlocksItem]) -> dict[AreaRoomPair, HatchLock]:
+def parse_door_lock_data(data: list[MarsschemamfDoorLocksItem]) -> dict[AreaRoomPair, HatchLock]:
     """Returns a dictionary of `(AreaID, RoomID): HatchLock` from the input data."""
     door_locks: dict[AreaRoomPair, HatchLock] = {}
     for entry in data:
-        area_door = (entry["Area"], entry["Door"])
-        lock = HATCH_LOCK_ENUMS[entry["LockType"]]
+        area_door = (entry["area"], entry["door"])
+        lock = HatchLock[entry["lock_type"]]
         door_locks[area_door] = lock
     return door_locks
 

--- a/src/mars_patcher/mf/item_patcher.py
+++ b/src/mars_patcher/mf/item_patcher.py
@@ -1,5 +1,5 @@
 from mars_patcher.item_messages import ItemMessages, ItemMessagesKind
-from mars_patcher.mf.auto_generated_types import MarsschemamfTankincrements
+from mars_patcher.mf.auto_generated_types import MarsschemamfTankIncrements
 from mars_patcher.mf.constants.items import ItemSprite, ItemType
 from mars_patcher.mf.constants.reserved_space import ReservedConstantsMF, ReservedPointersMF
 from mars_patcher.mf.locations import LocationSettings
@@ -229,9 +229,9 @@ def set_required_metroid_count(rom: Rom, count: int) -> None:
     rom.write_8(rom.read_ptr(METROID_PARAMETERS_ADDR) + 1, count)
 
 
-def set_tank_increments(rom: Rom, data: MarsschemamfTankincrements) -> None:
-    rom.write_16(rom.read_ptr(TANK_INC_ADDR), data["MissileTank"])
-    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 2, data["EnergyTank"])
-    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 4, data["PowerBombTank"])
-    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 6, data["MissileData"])
-    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 8, data["PowerBombData"])
+def set_tank_increments(rom: Rom, data: MarsschemamfTankIncrements) -> None:
+    rom.write_16(rom.read_ptr(TANK_INC_ADDR), data["missile_tank"])
+    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 2, data["energy_tank"])
+    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 4, data["power_bomb_tank"])
+    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 6, data["missile_data"])
+    rom.write_16(rom.read_ptr(TANK_INC_ADDR) + 8, data["power_bomb_data"])

--- a/src/mars_patcher/mf/locations.py
+++ b/src/mars_patcher/mf/locations.py
@@ -5,9 +5,6 @@ from typing_extensions import Self
 from mars_patcher.item_messages import ItemMessages
 from mars_patcher.mf.auto_generated_types import MarsschemamfLocations
 from mars_patcher.mf.constants.items import (
-    ITEM_ENUMS,
-    ITEM_SPRITE_ENUMS,
-    JINGLE_ENUMS,
     KEY_AREA,
     KEY_BLOCK_X,
     KEY_BLOCK_Y,
@@ -21,7 +18,6 @@ from mars_patcher.mf.constants.items import (
     KEY_ORIGINAL,
     KEY_ROOM,
     KEY_SOURCE,
-    SOURCE_ENUMS,
     ItemJingle,
     ItemSprite,
     ItemType,
@@ -103,8 +99,8 @@ class LocationSettings:
             major_loc = MajorLocation(
                 entry[KEY_AREA],
                 entry[KEY_ROOM],
-                SOURCE_ENUMS[entry[KEY_SOURCE]],
-                ITEM_ENUMS[entry[KEY_ORIGINAL]],
+                MajorSource[entry[KEY_SOURCE]],
+                ItemType[entry[KEY_ORIGINAL]],
             )
             major_locs.append(major_loc)
 
@@ -116,7 +112,7 @@ class LocationSettings:
                 entry[KEY_BLOCK_X],
                 entry[KEY_BLOCK_Y],
                 entry[KEY_HIDDEN],
-                ITEM_ENUMS[entry[KEY_ORIGINAL]],
+                ItemType[entry[KEY_ORIGINAL]],
             )
             minor_locs.append(minor_loc)
 
@@ -125,14 +121,14 @@ class LocationSettings:
     def set_assignments(self, data: MarsschemamfLocations) -> None:
         for maj_loc_entry in data[KEY_MAJOR_LOCS]:
             # Get source and item
-            source = SOURCE_ENUMS[maj_loc_entry[KEY_SOURCE]]
-            item = ITEM_ENUMS[maj_loc_entry[KEY_ITEM]]
+            source = MajorSource[maj_loc_entry[KEY_SOURCE]]
+            item = ItemType[maj_loc_entry[KEY_ITEM]]
             # Find location with this source
             maj_loc = next(m for m in self.major_locs if m.major_src == source)
             maj_loc.new_item = item
             if KEY_ITEM_MESSAGES in maj_loc_entry:
                 maj_loc.item_messages = ItemMessages.from_json(maj_loc_entry[KEY_ITEM_MESSAGES])
-            maj_loc.item_jingle = JINGLE_ENUMS[maj_loc_entry[KEY_ITEM_JINGLE]]
+            maj_loc.item_jingle = ItemJingle[maj_loc_entry[KEY_ITEM_JINGLE]]
         for min_loc_entry in data[KEY_MINOR_LOCS]:
             # Get area, room, block X, block Y
             area = min_loc_entry[KEY_AREA]
@@ -154,10 +150,10 @@ class LocationSettings:
                     f"Invalid minor location: Area {area}, Room {room}, X {block_x}, Y {block_y}"
                 )
             # Set item and item sprite
-            item = ITEM_ENUMS[min_loc_entry[KEY_ITEM]]
+            item = ItemType[min_loc_entry[KEY_ITEM]]
             min_loc.new_item = item
             if KEY_ITEM_SPRITE in min_loc_entry:
-                min_loc.item_sprite = ITEM_SPRITE_ENUMS[min_loc_entry[KEY_ITEM_SPRITE]]
+                min_loc.item_sprite = ItemSprite[min_loc_entry[KEY_ITEM_SPRITE]]
             if KEY_ITEM_MESSAGES in min_loc_entry:
                 min_loc.item_messages = ItemMessages.from_json(min_loc_entry[KEY_ITEM_MESSAGES])
-            min_loc.item_jingle = JINGLE_ENUMS[min_loc_entry[KEY_ITEM_JINGLE]]
+            min_loc.item_jingle = ItemJingle[min_loc_entry[KEY_ITEM_JINGLE]]

--- a/src/mars_patcher/mf/misc_patches.py
+++ b/src/mars_patcher/mf/misc_patches.py
@@ -1,5 +1,5 @@
 import mars_patcher.constants.game_data as gd
-from mars_patcher.mf.auto_generated_types import MarsschemamfEnvironmentaldamage
+from mars_patcher.mf.auto_generated_types import MarsschemamfEnvironmentalDamage
 from mars_patcher.mf.constants.reserved_space import ReservedPointersMF
 from mars_patcher.mf.data import get_data_path
 from mars_patcher.patching import BpsDecoder, IpsDecoder
@@ -86,15 +86,15 @@ def apply_alternative_health_layout(rom: Rom) -> None:
     rom.write_8(rom.read_ptr(ReservedPointersMF.USE_ALTERNATIVE_HUD_DISPLAY.value), 1)
 
 
-def apply_environmental_damage(rom: Rom, damage_dict: MarsschemamfEnvironmentaldamage) -> None:
+def apply_environmental_damage(rom: Rom, damage_dict: MarsschemamfEnvironmentalDamage) -> None:
     base_address = rom.read_ptr(ReservedPointersMF.ENVIRONMENTAL_HAZARD_DAMAGE_ADDR.value)
     damage = [
-        damage_dict["Lava"],
-        damage_dict["Acid"],
-        damage_dict["Heat"],
+        damage_dict["lava"],
+        damage_dict["acid"],
+        damage_dict["heat"],
         # ASM currently has Subzero and Cold mislabelled. https://github.com/MetroidAdvRandomizerSystem/mars-fusion-asm/issues/374
-        damage_dict["Cold"],
-        damage_dict["Subzero"],
+        damage_dict["cold"],
+        damage_dict["subzero"],
     ]
     for offset, damage_amount in enumerate(damage):
         rom.write_8(base_address + offset, damage_amount)

--- a/src/mars_patcher/mf/navigation_text.py
+++ b/src/mars_patcher/mf/navigation_text.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, IntEnum, auto
 from typing import TYPE_CHECKING
 
 from mars_patcher.mf.constants.game_data import navigation_text_ptrs
@@ -9,29 +9,29 @@ from mars_patcher.rom import Rom
 from mars_patcher.text import Language, MessageType, encode_text
 
 if TYPE_CHECKING:
-    from mars_patcher.mf.auto_generated_types import Hintlocks, MarsschemamfNavstationlocksKey
+    from mars_patcher.mf.auto_generated_types import HintLocks, MarsschemamfNavStationLocksKey
     from mars_patcher.rom import Rom
 
 
-class NavRoom(Enum):
+class NavRoom(IntEnum):
     MAIN_DECK_WEST = 1
-    MAIN_DECK_EAST = 2
-    OPERATIONS_DECK = 3
-    SECTOR1_ENTRANCE = 4
-    SECTOR5_ENTRANCE = 5
-    SECTOR2_ENTRANCE = 6
-    SECTOR4_ENTRANCE = 7
-    SECTOR3_ENTRANCE = 8
-    SECTOR6_ENTRANCE = 9
-    AUXILIARY_POWER = 10
-    RESTRICTED_LABS = 11
+    MAIN_DECK_EAST = auto()
+    OPERATIONS_DECK = auto()
+    SECTOR_1_ENTRANCE = auto()
+    SECTOR_5_ENTRANCE = auto()
+    SECTOR_2_ENTRANCE = auto()
+    SECTOR_4_ENTRANCE = auto()
+    SECTOR_3_ENTRANCE = auto()
+    SECTOR_6_ENTRANCE = auto()
+    AUXILIARY_POWER = auto()
+    RESTRICTED_LABS = auto()
 
 
 # Later down the line, when/if Nav terminals don't have their
 # confirm text patched out, combine these two.
 class ShipText(Enum):
-    INITIAL_TEXT = 0
-    CONFIRM_TEXT = 1
+    INITIAL_TEXT = auto()
+    CONFIRM_TEXT = auto()
 
 
 class NavStationLockType(Enum):
@@ -45,39 +45,9 @@ class NavStationLockType(Enum):
 
 
 class NavigationText:
-    LANG_ENUMS = {
-        "JapaneseKanji": Language.JAPANESE_KANJI,
-        "JapaneseHiragana": Language.JAPANESE_HIRAGANA,
-        "English": Language.ENGLISH,
-        "German": Language.GERMAN,
-        "French": Language.FRENCH,
-        "Italian": Language.ITALIAN,
-        "Spanish": Language.SPANISH,
-    }
-
-    NAV_ROOM_ENUMS: dict[MarsschemamfNavstationlocksKey, NavRoom] = {
-        "MainDeckWest": NavRoom.MAIN_DECK_WEST,
-        "MainDeckEast": NavRoom.MAIN_DECK_EAST,
-        "OperationsDeck": NavRoom.OPERATIONS_DECK,
-        "Sector1Entrance": NavRoom.SECTOR1_ENTRANCE,
-        "Sector2Entrance": NavRoom.SECTOR2_ENTRANCE,
-        "Sector3Entrance": NavRoom.SECTOR3_ENTRANCE,
-        "Sector4Entrance": NavRoom.SECTOR4_ENTRANCE,
-        "Sector5Entrance": NavRoom.SECTOR5_ENTRANCE,
-        "Sector6Entrance": NavRoom.SECTOR6_ENTRANCE,
-        "AuxiliaryPower": NavRoom.AUXILIARY_POWER,
-        "RestrictedLabs": NavRoom.RESTRICTED_LABS,
-    }
-
     GAME_START_CHAR = "[GAME_START]"
-    INITIAL_TEXT_KEY = "InitialText"
-    NAV_TERMINALS_KEY = "NavigationTerminals"
-    SHIP_TEXT_KEY = "ShipText"
-
-    INFO_TEXT_ENUMS = {
-        INITIAL_TEXT_KEY: ShipText.INITIAL_TEXT,
-        "ConfirmText": ShipText.CONFIRM_TEXT,
-    }
+    NAV_TERMINALS_KEY = "navigation_terminals"
+    SHIP_TEXT_KEY = "ship_text"
 
     def __init__(self, navigation_text: dict[Language, dict[str, dict[Enum, str]]]):
         self.navigation_text = navigation_text
@@ -86,15 +56,15 @@ class NavigationText:
     def from_json(cls, data: dict) -> NavigationText:
         navigation_text: dict[Language, dict[str, dict[Enum, str]]] = {}
         for lang, lang_text in data.items():
-            lang = cls.LANG_ENUMS[lang]
+            lang = Language[lang]
             navigation_text[lang] = {
                 cls.NAV_TERMINALS_KEY: {
-                    cls.NAV_ROOM_ENUMS[k]: v for k, v in lang_text[cls.NAV_TERMINALS_KEY].items()
+                    NavRoom[k]: v for k, v in lang_text[cls.NAV_TERMINALS_KEY].items()
                 },
                 cls.SHIP_TEXT_KEY: {
                     # Make sure initial text string starts with [GAME_START]
-                    cls.INFO_TEXT_ENUMS[k]: cls.GAME_START_CHAR + v
-                    if k == cls.INITIAL_TEXT_KEY and not v.startswith(cls.GAME_START_CHAR)
+                    ShipText[k]: cls.GAME_START_CHAR + v
+                    if k == ShipText.INITIAL_TEXT.name and not v.startswith(cls.GAME_START_CHAR)
                     else v
                     for k, v in lang_text[cls.SHIP_TEXT_KEY].items()
                 },
@@ -106,28 +76,29 @@ class NavigationText:
             base_text_address = rom.read_ptr(navigation_text_ptrs(rom) + lang.value * 4)
 
             # Info Text
-            for info_place, text in lang_texts["ShipText"].items():
+            for info_place, text in lang_texts["ship_text"].items():
                 encoded_text = encode_text(rom, MessageType.CONTINUOUS, text)
                 text_ptr = base_text_address + info_place.value * 4
                 rom.write_data_with_pointers(encoded_text, [text_ptr, text_ptr + 4])
 
             # Navigation Text
-            for nav_room, text in lang_texts["NavigationTerminals"].items():
+            for nav_room, text in lang_texts["navigation_terminals"].items():
                 encoded_text = encode_text(rom, MessageType.CONTINUOUS, text)
                 text_ptr = base_text_address + nav_room.value * 8
                 rom.write_data_with_pointers(encoded_text, [text_ptr, text_ptr + 4])
 
     @classmethod
     def apply_hint_security(
-        cls, rom: Rom, locks: dict[MarsschemamfNavstationlocksKey, Hintlocks]
+        cls, rom: Rom, locks: dict[MarsschemamfNavStationLocksKey, HintLocks]
     ) -> None:
         """
         Applies an optional security level requirement to use Navigation Stations
         Defaults to OPEN if not provided in patch data JSON
         """
-        default_lock_name = "OPEN"
-        for location, offset in NavigationText.NAV_ROOM_ENUMS.items():
+        locks_values = {NavRoom[k]: NavStationLockType[v] for k, v in locks.items()}
+        default_lock = NavStationLockType.OPEN
+        for location in NavRoom:
             rom.write_8(
-                rom.read_ptr(ReservedPointersMF.HINT_SECURITY_LEVELS_ADDR.value) + offset.value,
-                NavStationLockType[locks.get(location, default_lock_name)].value,
+                rom.read_ptr(ReservedPointersMF.HINT_SECURITY_LEVELS_ADDR.value) + location.value,
+                locks_values.get(location, default_lock).value,
             )

--- a/src/mars_patcher/mf/patcher.py
+++ b/src/mars_patcher/mf/patcher.py
@@ -65,118 +65,118 @@ def patch_mf(
 
     # Randomize palettes - palettes are randomized first in case the item
     # patcher needs to copy tilesets
-    if "Palettes" in patch_data:
+    if "palettes" in patch_data:
         status_update("Randomizing palettes...", -1)
-        pal_settings = PaletteSettings.from_json(patch_data["Palettes"])
+        pal_settings = PaletteSettings.from_json(patch_data["palettes"])
         pal_randomizer = PaletteRandomizer(rom, pal_settings)
         pal_randomizer.randomize()
 
     # Load locations and set assignments
     status_update("Writing item assignments...", -1)
     loc_settings = LocationSettings.initialize()
-    loc_settings.set_assignments(patch_data["Locations"])
+    loc_settings.set_assignments(patch_data["locations"])
     item_patcher = ItemPatcher(rom, loc_settings)
     item_patcher.write_items()
 
     # Required metroid count
-    set_required_metroid_count(rom, patch_data["RequiredMetroidCount"])
+    set_required_metroid_count(rom, patch_data["required_metroid_count"])
 
     # Music
-    if "MusicReplacement" in patch_data:
+    if "music_replacement" in patch_data:
         status_update("Writing music...", -1)
-        set_sounds(rom, patch_data["MusicReplacement"])
+        set_sounds(rom, patch_data["music_replacement"])
 
     # Starting location
-    if "StartingLocation" in patch_data:
+    if "starting_location" in patch_data:
         status_update("Writing starting location...", -1)
-        set_starting_location(rom, patch_data["StartingLocation"])
+        set_starting_location(rom, patch_data["starting_location"])
 
     # Starting items
-    if "StartingItems" in patch_data:
+    if "starting_items" in patch_data:
         status_update("Writing starting items...", -1)
-        set_starting_items(rom, patch_data["StartingItems"])
+        set_starting_items(rom, patch_data["starting_items"])
 
     # Tank increments
-    if "TankIncrements" in patch_data:
+    if "tank_increments" in patch_data:
         status_update("Writing tank increments...", -1)
-        set_tank_increments(rom, patch_data["TankIncrements"])
+        set_tank_increments(rom, patch_data["tank_increments"])
 
     # Elevator connections
     conns = None
-    if "ElevatorConnections" in patch_data:
+    if "elevator_connections" in patch_data:
         status_update("Writing elevator connections...", -1)
         conns = Connections(rom)
-        conns.set_elevator_connections(patch_data["ElevatorConnections"])
+        conns.set_elevator_connections(patch_data["elevator_connections"])
 
     # Sector shortcuts
-    if "SectorShortcuts" in patch_data:
+    if "sector_shortcuts" in patch_data:
         status_update("Writing sector shortcuts...", -1)
         if conns is None:
             conns = Connections(rom)
-        conns.set_shortcut_connections(patch_data["SectorShortcuts"])
+        conns.set_shortcut_connections(patch_data["sector_shortcuts"])
 
     # Hints
-    if nav_text := patch_data.get("NavigationText", {}):
+    if nav_text := patch_data.get("navigation_text", {}):
         status_update("Writing navigation text...", -1)
         navigation_text = NavigationText.from_json(nav_text)
         navigation_text.write(rom)
 
-    if nav_locks := patch_data.get("NavStationLocks", {}):
+    if nav_locks := patch_data.get("nav_station_locks", {}):
         status_update("Writing navigation locks...", -1)
         NavigationText.apply_hint_security(rom, nav_locks)
 
     # Room Names
-    if room_names := patch_data.get("RoomNames", []):
+    if room_names := patch_data.get("room_names", []):
         status_update("Writing room names...", -1)
         write_room_names(rom, room_names)
 
     # Credits
-    if credits_text := patch_data.get("CreditsText", []):
+    if credits_text := patch_data.get("credits_text", []):
         status_update("Writing credits text...", -1)
         write_credits(rom, credits_text)
 
     # Misc patches
-    if patch_data.get("DisableDemos"):
+    if patch_data.get("disable_demos"):
         disable_demos(rom)
 
-    if patch_data.get("InstantUnmorph"):
+    if patch_data.get("instant_unmorph"):
         apply_instant_unmorph_patch(rom)
 
-    if patch_data.get("SkipDoorTransitions"):
+    if patch_data.get("skip_door_transitions"):
         skip_door_transitions(rom)
 
-    if patch_data.get("StereoDefault", True):
+    if patch_data.get("stereo_default", True):
         stereo_default(rom)
 
-    if patch_data.get("DisableMusic"):
+    if patch_data.get("disable_music"):
         disable_music(rom)
 
-    if patch_data.get("DisableSoundEffects"):
+    if patch_data.get("disable_sound_effects"):
         disable_sound_effects(rom)
 
-    if environmental_damage := patch_data.get("EnvironmentalDamage"):
+    if environmental_damage := patch_data.get("environmental_damage"):
         apply_environmental_damage(rom, environmental_damage)
 
-    if "MissileLimit" in patch_data:
-        change_missile_limit(rom, patch_data["MissileLimit"])
+    if "missile_limit" in patch_data:
+        change_missile_limit(rom, patch_data["missile_limit"])
 
-    if patch_data.get("NerfGerons"):
+    if patch_data.get("nerf_gerons"):
         apply_nerf_gerons(rom)
 
-    if patch_data.get("UseAlternativeHudHealthLayout"):
+    if patch_data.get("use_alternative_hud_health_layout"):
         apply_alternative_health_layout(rom)
 
-    if patch_data.get("UnexploredMap"):
+    if patch_data.get("unexplored_map"):
         apply_unexplored_map(rom)
 
-        if not patch_data.get("HideDoorsOnMinimap", False):
+        if not patch_data.get("hide_doors_on_minimap", False):
             apply_reveal_unexplored_doors(rom)
 
-    if patch_data.get("RevealHiddenTiles"):
+    if patch_data.get("reveal_hidden_tiles"):
         apply_reveal_hidden_tiles(rom)
 
-    if "LevelEdits" in patch_data:
-        apply_level_edits(rom, patch_data["LevelEdits"])
+    if "level_edits" in patch_data:
+        apply_level_edits(rom, patch_data["level_edits"])
 
     # Apply base minimap edits
     with open(get_data_path("base_minimap_edits.json")) as f:
@@ -184,18 +184,18 @@ def patch_mf(
     apply_minimap_edits(rom, edits_dict)
 
     # Apply JSON minimap edits
-    if "MinimapEdits" in patch_data:
-        apply_minimap_edits(rom, patch_data["MinimapEdits"])
+    if "minimap_edits" in patch_data:
+        apply_minimap_edits(rom, patch_data["minimap_edits"])
 
     # Door locks
-    if door_locks := patch_data.get("DoorLocks", []):
+    if door_locks := patch_data.get("door_locks", []):
         status_update("Writing door locks...", -1)
         set_door_locks(rom, door_locks)
 
-    write_seed_hash(rom, patch_data["SeedHash"])
+    write_seed_hash(rom, patch_data["seed_hash"])
 
     # Title screen text
-    if title_screen_text := patch_data.get("TitleText"):
+    if title_screen_text := patch_data.get("title_text"):
         status_update("Writing title screen text...", -1)
         write_title_text(rom, title_screen_text)
 

--- a/src/mars_patcher/mf/starting.py
+++ b/src/mars_patcher/mf/starting.py
@@ -1,7 +1,7 @@
 from mars_patcher.constants.game_data import area_doors_ptrs, spriteset_ptrs
 from mars_patcher.mf.auto_generated_types import (
-    MarsschemamfStartingitems,
-    MarsschemamfStartinglocation,
+    MarsschemamfStartingItems,
+    MarsschemamfStartingLocation,
 )
 from mars_patcher.mf.constants.game_data import starting_equipment
 from mars_patcher.mf.constants.items import BEAM_FLAGS, MISSILE_BOMB_FLAGS, SUIT_MISC_FLAGS
@@ -13,9 +13,9 @@ from mars_patcher.room_entry import RoomEntry
 STARTING_LOC_ADDR = ReservedPointersMF.STARTING_LOCATION_ADDR.value
 
 
-def set_starting_location(rom: Rom, data: MarsschemamfStartinglocation) -> None:
-    area = data["Area"]
-    room = data["Room"]
+def set_starting_location(rom: Rom, data: MarsschemamfStartingLocation) -> None:
+    area = data["area"]
+    room = data["room"]
     # Don't do anything for area 0 room 0
     if area == 0 and room == 0:
         return
@@ -27,8 +27,8 @@ def set_starting_location(rom: Rom, data: MarsschemamfStartinglocation) -> None:
         x_pos, y_pos = pos
     else:
         # Convert block coordinates to actual position
-        x_pos = data["BlockX"] * 64 + 31
-        y_pos = data["BlockY"] * 64 + 63
+        x_pos = data["block_x"] * 64 + 31
+        y_pos = data["block_y"] * 64 + 63
     # Write to rom
     starting_location = rom.read_ptr(STARTING_LOC_ADDR)
     rom.write_8(starting_location, area)
@@ -86,7 +86,7 @@ def find_save_pad_position(rom: Rom, area: int, room: int) -> tuple[int, int] | 
     return None
 
 
-def set_starting_items(rom: Rom, data: MarsschemamfStartingitems) -> None:
+def set_starting_items(rom: Rom, data: MarsschemamfStartingItems) -> None:
     def get_ability_flags(ability_flags: dict[str, int]) -> int:
         status = 0
         for ability, flag in ability_flags.items():
@@ -95,21 +95,21 @@ def set_starting_items(rom: Rom, data: MarsschemamfStartingitems) -> None:
         return status
 
     # Get health/ammo amounts
-    energy = data.get("Energy", 99)
-    missiles = data.get("Missiles", 10)
-    power_bombs = data.get("PowerBombs", 10)
+    energy = data.get("energy", 99)
+    missiles = data.get("missiles", 10)
+    power_bombs = data.get("power_bombs", 10)
     # Get ability status flags
-    abilities = data.get("Abilities", [])
+    abilities = data.get("abilities", [])
     beam_status = get_ability_flags(BEAM_FLAGS)
     missile_bomb_status = get_ability_flags(MISSILE_BOMB_FLAGS)
     suit_misc_status = get_ability_flags(SUIT_MISC_FLAGS)
     # Get security level flags
-    levels = data.get("SecurityLevels", [0])
+    levels = data.get("security_levels", [0])
     level_status = 0
     for level in levels:
         level_status |= 1 << level
     # Get downloaded map flags
-    maps = data.get("DownloadedMaps", range(7))
+    maps = data.get("downloaded_maps", range(7))
     map_status = 0
     for map in maps:
         map_status |= 1 << map

--- a/src/mars_patcher/random_palettes.py
+++ b/src/mars_patcher/random_palettes.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 import mars_patcher.constants.game_data as gd
 from mars_patcher.mf.auto_generated_types import (
     MarsschemamfPalettes,
-    MarsschemamfPalettesColorspace,
+    MarsschemamfPalettesColorSpace,
     MarsschemamfPalettesRandomize,
 )
 from mars_patcher.mf.constants.game_data import sax_palettes, sprite_vram_sizes
@@ -24,7 +24,7 @@ from mars_patcher.rom import Rom
 from mars_patcher.tileset import Tileset
 from mars_patcher.zm.auto_generated_types import (
     MarsschemazmPalettes,
-    MarsschemazmPalettesColorspace,
+    MarsschemazmPalettesColorSpace,
     MarsschemazmPalettesRandomize,
 )
 from mars_patcher.zm.constants.game_data import (
@@ -35,7 +35,7 @@ from mars_patcher.zm.constants.palettes import ENEMY_GROUPS_ZM, EXCLUDED_ENEMIES
 from mars_patcher.zm.constants.sprites import SpriteIdZM
 
 SchemaPalettes = MarsschemamfPalettes | MarsschemazmPalettes
-SchemaPalettesColorspace = MarsschemamfPalettesColorspace | MarsschemazmPalettesColorspace
+SchemaPalettesColorSpace = MarsschemamfPalettesColorSpace | MarsschemazmPalettesColorSpace
 SchemaPalettesRandomize = MarsschemamfPalettesRandomize | MarsschemazmPalettesRandomize
 
 HueRange: TypeAlias = tuple[int, int]
@@ -49,45 +49,38 @@ class PaletteType(Enum):
 
 
 class PaletteSettings:
-    PAL_TYPE_ENUMS = {
-        "Tilesets": PaletteType.TILESETS,
-        "Enemies": PaletteType.ENEMIES,
-        "Samus": PaletteType.SAMUS,
-        "Beams": PaletteType.BEAMS,
-    }
-
     def __init__(
         self,
         seed: int,
         pal_types: dict[PaletteType, HueRange],
-        color_space: SchemaPalettesColorspace,
+        color_space: SchemaPalettesColorSpace,
         symmetric: bool,
         extra_variation: bool,
     ):
         self.seed = seed
         self.pal_types = pal_types
-        self.color_space: SchemaPalettesColorspace = color_space
+        self.color_space: SchemaPalettesColorSpace = color_space
         self.symmetric = symmetric
         self.extra_variation = extra_variation
 
     @classmethod
     def from_json(cls, data: SchemaPalettes) -> Self:
-        seed = data.get("Seed", random.randint(0, 2**31 - 1))
+        seed = data.get("seed", random.randint(0, 2**31 - 1))
         random.seed(seed)
         pal_types = {}
-        for type_name, hue_data in data["Randomize"].items():
-            pal_type = cls.PAL_TYPE_ENUMS[type_name]
+        for type_name, hue_data in data["randomize"].items():
+            pal_type = PaletteType[type_name]
             hue_range = cls.get_hue_range(hue_data)
             pal_types[pal_type] = hue_range
-        color_space = data.get("ColorSpace", "Oklab")
-        symmetric = data.get("Symmetric", True)
+        color_space = data.get("color_space", "OKLAB")
+        symmetric = data.get("symmetric", True)
         # Extra variation is always enabled. This could be passed via JSON instead.
         return cls(seed, pal_types, color_space, symmetric, True)
 
     @classmethod
     def get_hue_range(cls, data: SchemaPalettesRandomize) -> HueRange:
-        hue_min = data.get("HueMin")
-        hue_max = data.get("HueMax")
+        hue_min = data.get("hue_min")
+        hue_max = data.get("hue_max")
         if hue_min is None or hue_max is None:
             if hue_max is not None:
                 hue_min = random.randint(0, hue_max)
@@ -109,7 +102,7 @@ class PaletteRandomizer:
         self.settings = settings
         if settings.color_space == "HSV":
             self.change_func = self.change_palette_hsv
-        elif settings.color_space == "Oklab":
+        elif settings.color_space == "OKLAB":
             self.change_func = self.change_palette_oklab
         else:
             raise ValueError(f"Invalid color space '{settings.color_space}' for color space!")

--- a/src/mars_patcher/room_names.py
+++ b/src/mars_patcher/room_names.py
@@ -1,12 +1,7 @@
-import mars_patcher.mf.auto_generated_types as mf_types
-import mars_patcher.zm.auto_generated_types as zm_types
+from mars_patcher.common_types import AreaId, RoomNamesItem, TypeU8
 from mars_patcher.constants.game_data import room_names_addr
 from mars_patcher.rom import Rom
 from mars_patcher.text import MAX_LINE_WIDTH, MessageType, encode_text
-
-AreaId = mf_types.Areaid | zm_types.AreaId
-RoomNamesItem = mf_types.MarsschemamfRoomnamesItem | zm_types.MarsschemazmRoomnamesItem
-TypeU8 = mf_types.Typeu8 | zm_types.TypeU8
 
 
 # ROM has:
@@ -22,9 +17,9 @@ def write_room_names(rom: Rom, data: list[RoomNamesItem]) -> None:
     seen_rooms: set[tuple[AreaId, TypeU8]] = set()
 
     for room_name_entry in data:
-        area_id = room_name_entry["Area"]
-        room_id = room_name_entry["Room"]
-        room_name = room_name_entry["Name"]
+        area_id = room_name_entry["area"]
+        room_id = room_name_entry["room"]
+        room_name = room_name_entry["name"]
 
         # Check that the room wasn't already set
         assert (area_id, room_id) not in seen_rooms, "Duplicate room name provided."

--- a/src/mars_patcher/tilemap.py
+++ b/src/mars_patcher/tilemap.py
@@ -114,10 +114,10 @@ def apply_minimap_edits(rom: Rom, edit_dict: dict) -> None:
         with Tilemap.from_minimap(rom, int(map_id)) as minimap:
             for change in changes:
                 minimap.set_tile_value(
-                    change["X"],
-                    change["Y"],
-                    change["Tile"],
-                    change["Palette"],
-                    change.get("HFlip", False),
-                    change.get("VFlip", False),
+                    change["x"],
+                    change["y"],
+                    change["tile"],
+                    change["palette"],
+                    change.get("h_flip", False),
+                    change.get("v_flip", False),
                 )

--- a/src/mars_patcher/title_screen_text.py
+++ b/src/mars_patcher/title_screen_text.py
@@ -4,7 +4,7 @@ from mars_patcher.constants.game_data import title_text_addr
 from mars_patcher.mf.constants.reserved_space import ReservedPointersMF
 from mars_patcher.rom import Rom
 
-TitleTextItem = mf_types.MarsschemamfTitletextItem | zm_types.MarsschemazmTitleTextItem
+TitleTextItem = mf_types.MarsschemamfTitleTextItem | zm_types.MarsschemazmTitleTextItem
 
 TITLE_TEXT_POINTER_ADDR = ReservedPointersMF.TITLE_SCREEN_TEXT_POINTERS_POINTER_ADDR.value
 MAX_LENGTH = 30
@@ -16,12 +16,12 @@ def write_title_text(rom: Rom, lines: list[TitleTextItem]) -> None:
     line_ptrs = title_text_addr(rom)
 
     for line in lines:
-        line_num = line["LineNum"]
+        line_num = line["line_num"]
         if line_num in seen_lines:
             raise ValueError(f"Title screen text line {line_num} already provided")
         seen_lines.add(line_num)
 
-        text = line["Text"]
+        text = line["text"]
         if len(text) > MAX_LENGTH:
             raise ValueError(f'Title screen text line exceeds {MAX_LENGTH} characters\n"{text}"')
 

--- a/src/mars_patcher/zm/auto_generated_types.py
+++ b/src/mars_patcher/zm/auto_generated_types.py
@@ -146,15 +146,15 @@ ValidElevatorBottoms = typ.Literal[
     'TOURIAN_TO_CRATERIA'
 ]
 ValidLanguages = typ.Literal[
-    'JapaneseKanji',
-    'JapaneseHiragana',
-    'English',
-    'German',
-    'French',
-    'Italian',
-    'Spanish'
+    'JAPANESE_KANJI',
+    'JAPANESE_HIRAGANA',
+    'ENGLISH',
+    'GERMAN',
+    'FRENCH',
+    'ITALIAN',
+    'SPANISH'
 ]
-Validmusictracks = typ.Literal[
+ValidMusicTracks = typ.Literal[
     'BRINSTAR',
     'TITLE_SCREEN',
     'SAVE_ELEVATOR_ROOM',
@@ -218,19 +218,19 @@ Validmusictracks = typ.Literal[
     'BEFORE_RUINS_TEST_ROOM',
     'STEALTH_2'
 ]
-Musicmapping: typ.TypeAlias = dict[Validmusictracks, Validmusictracks]
+MusicMapping: typ.TypeAlias = dict[ValidMusicTracks, ValidMusicTracks]
 MessageLanguages: typ.TypeAlias = dict[ValidLanguages, str]
 
 class ItemMessages(typ.TypedDict, total=False):
-    Kind: typ.Required[ItemMessagesKind]
-    Languages: MessageLanguages
-    Centered: bool = True
-    MessageID: typ.Annotated[int, '0 <= value <= 56']
+    kind: typ.Required[ItemMessagesKind]
+    languages: MessageLanguages
+    centered: bool = True
+    message_id: typ.Annotated[int, '0 <= value <= 56']
     """The Message ID, will display one of the predefined messages in the ROM"""
 
 ItemMessagesKind = typ.Literal[
-    'CustomMessage',
-    'MessageID'
+    'CUSTOM_MESSAGE',
+    'MESSAGE_ID'
 ]
 Jingle = typ.Literal[
     'DEFAULT',
@@ -275,7 +275,7 @@ class MarsschemazmLocationsMajorLocationsItem(typ.TypedDict, total=False):
     item_sprite: ValidItemSprites
     """Valid graphics for item tanks/sprites."""
 
-    ItemMessages: ItemMessages
+    item_messages: ItemMessages
     jingle: Jingle
     """The sound that plays when an item is collected"""
 
@@ -302,7 +302,7 @@ class MarsschemazmLocationsMinorLocationsItem(typ.TypedDict):
     item_sprite: typ.NotRequired[ValidItemSprites]
     """Valid graphics for item tanks/sprites."""
 
-    ItemMessages: typ.NotRequired[ItemMessages]
+    item_messages: typ.NotRequired[ItemMessages]
     jingle: typ.NotRequired[Jingle]
     """The sound that plays when an item is collected"""
 
@@ -421,42 +421,42 @@ class MarsschemazmDoorLocksItem(typ.TypedDict):
     """The type of cover on the hatch."""
 
 MarsschemazmPalettesRandomizeKey = typ.Literal[
-    'Tilesets',
-    'Enemies',
-    'Samus',
-    'Beams'
+    'TILESETS',
+    'ENEMIES',
+    'SAMUS',
+    'BEAMS'
 ]
 
 @typ.final
 class MarsschemazmPalettesRandomize(typ.TypedDict, total=False):
     """The range to use for rotating palette hues."""
 
-    HueMin: HueRotation = None
+    hue_min: HueRotation = None
     """The minimum value to use for rotating palette hues. If not specified, the patcher will randomly generate one."""
 
-    HueMax: HueRotation = None
+    hue_max: HueRotation = None
     """The maximum value to use for rotating palette hues. If not specified, the patcher will randomly generate one."""
 
 
-MarsschemazmPalettesColorspace = typ.Literal[
+MarsschemazmPalettesColorSpace = typ.Literal[
     'HSV',
-    'Oklab'
+    'OKLAB'
 ]
 
 @typ.final
 class MarsschemazmPalettes(typ.TypedDict, total=False):
     """Properties for randomized in-game palettes."""
 
-    Seed: Seed = None
+    seed: Seed = None
     """A number used to initialize the random number generator for palettes. If not specified, the patcher will randomly generate one."""
 
-    Randomize: typ.Required[dict[MarsschemazmPalettesRandomizeKey, MarsschemazmPalettesRandomize]]
+    randomize: typ.Required[dict[MarsschemazmPalettesRandomizeKey, MarsschemazmPalettesRandomize]]
     """What kind of palettes should be randomized."""
 
-    ColorSpace: MarsschemazmPalettesColorspace = 'Oklab'
+    color_space: MarsschemazmPalettesColorSpace = 'OKLAB'
     """The color space to use for rotating palette hues."""
 
-    Symmetric: bool = True
+    symmetric: bool = True
     """Randomly rotates hues in the positive or negative direction true."""
 
 
@@ -491,29 +491,29 @@ class MarsschemazmHintText(typ.TypedDict, total=False):
 
 
 class MarsschemazmTitleTextItem(typ.TypedDict, total=False):
-    Text: typ.Annotated[str, '/^[ -~]{0,30}$/']
+    text: typ.Annotated[str, '/^[ -~]{0,30}$/']
     """The ASCII text for this line"""
 
-    LineNum: typ.Annotated[int, '0 <= value <= 20']
-MarsschemazmCreditsTextItemLinetype = typ.Literal[
-    'Blank',
-    'Blue',
-    'Red',
-    'White1',
-    'White2'
+    line_num: typ.Annotated[int, '0 <= value <= 20']
+MarsschemazmCreditsTextItemLineType = typ.Literal[
+    'BLANK',
+    'BLUE',
+    'RED',
+    'WHITE',
+    'WHITE_BIG'
 ]
 
 class MarsschemazmCreditsTextItem(typ.TypedDict, total=False):
-    LineType: typ.Required[MarsschemazmCreditsTextItemLinetype]
+    line_type: typ.Required[MarsschemazmCreditsTextItemLineType]
     """The color and line height of the text (or blank)."""
 
-    Text: typ.Annotated[str, '/^[ -~]{0,34}$/']
+    text: typ.Annotated[str, '/^[ -~]{0,34}$/']
     """The ASCII text for this line."""
 
-    BlankLines: TypeU8 = 0
+    blank_lines: TypeU8 = 0
     """Inserts the provided number of blank lines after the text line."""
 
-    Centered: bool = True
+    centered: bool = True
     """Centers the text horizontally when true."""
 
 
@@ -554,14 +554,14 @@ class MarsschemazmMinimapEditsItem(typ.TypedDict, total=False):
 
 
 
-class MarsschemazmRoomnamesItem(typ.TypedDict):
-    Area: AreaId
+class MarsschemazmRoomNamesItem(typ.TypedDict):
+    area: AreaId
     """The area ID where this room is located."""
 
-    Room: TypeU8 = 0
+    room: TypeU8 = 0
     """The room ID."""
 
-    Name: typ.Annotated[str, 'len() <= 224']
+    name: typ.Annotated[str, 'len() <= 224']
     """Specifies what text should appear for this room. Two lines are available, with an absolute maximum of 112 characters per line, if all characters used are small. Text will auto-wrap if the next word doesn't fit on the line. If the text is too long, it will be truncated. Use 
  to force a line break. If not provided, will display 'Room name not provided'."""
 
@@ -592,10 +592,10 @@ class Marsschemazm(typ.TypedDict, total=False):
     door_locks: list[MarsschemazmDoorLocksItem]
     """List of all lockable doors and their lock type."""
 
-    Palettes: MarsschemazmPalettes = None
+    palettes: MarsschemazmPalettes = None
     """Properties for randomized in-game palettes."""
 
-    MusicReplacement: Musicmapping
+    music_replacement: MusicMapping
     """Shuffles the in-game music."""
 
     intro_text: dict[ValidLanguages, str] = None
@@ -640,7 +640,7 @@ class Marsschemazm(typ.TypedDict, total=False):
     hide_doors_on_minimap: bool = False
     """When enabled, hides doors on the minimap. This is automatically enabled when the 'DoorLocks' field is provided."""
 
-    RoomNames: typ.Annotated[list[MarsschemazmRoomnamesItem], 'Unique items']
+    room_names: typ.Annotated[list[MarsschemazmRoomNamesItem], 'Unique items']
     """Specifies a name to be displayed when the A Button is pressed on the pause menu."""
 
     reveal_hidden_tiles: bool = False

--- a/src/mars_patcher/zm/data/schema.json
+++ b/src/mars_patcher/zm/data/schema.json
@@ -31,7 +31,7 @@
                             "item_sprite": {
                                 "$ref": "#/$defs/valid_item_sprites"
                             },
-                            "ItemMessages": {
+                            "item_messages": {
                                 "$ref": "#/$defs/item_messages"
                             },
                             "jingle": {
@@ -79,7 +79,7 @@
                             "item_sprite": {
                                 "$ref": "#/$defs/valid_item_sprites"
                             },
-                            "ItemMessages": {
+                            "item_messages": {
                                 "$ref": "#/$defs/item_messages"
                             },
                             "jingle": {
@@ -328,37 +328,37 @@
                 ]
             }
         },
-        "Palettes": {
+        "palettes": {
             "type": "object",
             "description": "Properties for randomized in-game palettes.",
             "properties": {
-                "Seed": {
+                "seed": {
                     "$ref": "#/$defs/seed",
                     "description": "A number used to initialize the random number generator for palettes. If not specified, the patcher will randomly generate one.",
                     "default": null
                 },
-                "Randomize": {
+                "randomize": {
                     "type": "object",
                     "description": "What kind of palettes should be randomized.",
                     "propertyNames": {
                         "type": "string",
                         "enum": [
-                            "Tilesets",
-                            "Enemies",
-                            "Samus",
-                            "Beams"
+                            "TILESETS",
+                            "ENEMIES",
+                            "SAMUS",
+                            "BEAMS"
                         ]
                     },
                     "additionalProperties": {
                         "type": "object",
                         "description": "The range to use for rotating palette hues.",
                         "properties": {
-                            "HueMin": {
+                            "hue_min": {
                                 "$ref": "#/$defs/hue_rotation",
                                 "description": "The minimum value to use for rotating palette hues. If not specified, the patcher will randomly generate one.",
                                 "default": null
                             },
-                            "HueMax": {
+                            "hue_max": {
                                 "$ref": "#/$defs/hue_rotation",
                                 "description": "The maximum value to use for rotating palette hues. If not specified, the patcher will randomly generate one.",
                                 "default": null
@@ -367,16 +367,16 @@
                         "additionalProperties": false
                     }
                 },
-                "ColorSpace": {
+                "color_space": {
                     "type": "string",
                     "description": "The color space to use for rotating palette hues.",
                     "enum": [
                         "HSV",
-                        "Oklab"
+                        "OKLAB"
                     ],
-                    "default": "Oklab"
+                    "default": "OKLAB"
                 },
-                "Symmetric": {
+                "symmetric": {
                     "type": "boolean",
                     "description": "Randomly rotates hues in the positive or negative direction true.",
                     "default": true
@@ -384,13 +384,13 @@
             },
             "additionalProperties": false,
             "required": [
-                "Randomize"
+                "randomize"
             ],
             "default": null
         },
-        "MusicReplacement": {
+        "music_replacement": {
             "description": "Shuffles the in-game music.",
-            "$ref": "#/$defs/MusicMapping"
+            "$ref": "#/$defs/music_mapping"
         },
         "intro_text": {
             "type": "object",
@@ -457,12 +457,12 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "Text": {
+                    "text": {
                         "type": "string",
                         "description": "The ASCII text for this line",
                         "pattern": "^[ -~]{0,30}$"
                     },
-                    "LineNum": {
+                    "line_num": {
                         "type": "integer",
                         "minimum": 0,
                         "maximum": 20
@@ -477,35 +477,35 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "LineType": {
+                    "line_type": {
                         "type": "string",
                         "description": "The color and line height of the text (or blank).",
                         "enum": [
-                            "Blank",
-                            "Blue",
-                            "Red",
-                            "White1",
-                            "White2"
+                            "BLANK",
+                            "BLUE",
+                            "RED",
+                            "WHITE",
+                            "WHITE_BIG"
                         ]
                     },
-                    "Text": {
+                    "text": {
                         "type": "string",
                         "description": "The ASCII text for this line.",
                         "pattern": "^[ -~]{0,34}$"
                     },
-                    "BlankLines": {
+                    "blank_lines": {
                         "$ref": "#/$defs/type_u8",
                         "description": "Inserts the provided number of blank lines after the text line.",
                         "default": 0
                     },
-                    "Centered": {
+                    "centered": {
                         "type": "boolean",
                         "description": "Centers the text horizontally when true.",
                         "default": true
                     }
                 },
                 "required": [
-                    "LineType"
+                    "line_type"
                 ]
             }
         },
@@ -623,31 +623,31 @@
             "description": "When enabled, hides doors on the minimap. This is automatically enabled when the 'DoorLocks' field is provided.",
             "default": false
         },
-        "RoomNames": {
+        "room_names": {
             "type": "array",
             "description": "Specifies a name to be displayed when the A Button is pressed on the pause menu.",
             "uniqueItems": true,
             "items": {
                 "type": "object",
                 "properties": {
-                    "Area": {
+                    "area": {
                         "$ref": "#/$defs/area_id",
                         "description": "The area ID where this room is located."
                     },
-                    "Room": {
+                    "room": {
                         "$ref": "#/$defs/type_u8",
                         "description": "The room ID."
                     },
-                    "Name": {
+                    "name": {
                         "type": "string",
                         "description": "Specifies what text should appear for this room. Two lines are available, with an absolute maximum of 112 characters per line, if all characters used are small. Text will auto-wrap if the next word doesn't fit on the line. If the text is too long, it will be truncated. Use \n to force a line break. If not provided, will display 'Room name not provided'.",
                         "maxLength": 224
                     }
                 },
                 "required": [
-                    "Area",
-                    "Room",
-                    "Name"
+                    "area",
+                    "room",
+                    "name"
                 ]
             }
         },
@@ -861,16 +861,16 @@
             "type": "string",
             "description": "Valid languages supported by the game.",
             "enum": [
-                "JapaneseKanji",
-                "JapaneseHiragana",
-                "English",
-                "German",
-                "French",
-                "Italian",
-                "Spanish"
+                "JAPANESE_KANJI",
+                "JAPANESE_HIRAGANA",
+                "ENGLISH",
+                "GERMAN",
+                "FRENCH",
+                "ITALIAN",
+                "SPANISH"
             ]
         },
-        "ValidMusicTracks": {
+        "valid_music_tracks": {
             "type": "string",
             "description": "Valid music tracks supported by the game.",
             "enum": [
@@ -938,14 +938,14 @@
                 "STEALTH_2"
             ]
         },
-        "MusicMapping": {
+        "music_mapping": {
             "description": "Maps music tracks to each other",
             "type": "object",
             "propertyNames": {
-                "$ref": "#/$defs/ValidMusicTracks"
+                "$ref": "#/$defs/valid_music_tracks"
             },
             "additionalProperties": {
-                "$ref": "#/$defs/ValidMusicTracks"
+                "$ref": "#/$defs/valid_music_tracks"
             }
         },
         "message_languages": {
@@ -954,7 +954,7 @@
                 "$ref": "#/$defs/valid_languages"
             },
             "required": [
-                "English"
+                "ENGLISH"
             ],
             "additionalProperties": {
                 "type": "string",
@@ -964,44 +964,44 @@
         "item_messages": {
             "type": "object",
             "properties": {
-                "Kind": {
+                "kind": {
                     "$ref": "#/$defs/item_messages_kind"
                 }
             },
             "required": [
-                "Kind"
+                "kind"
             ],
             "if": {
                 "properties": {
-                    "Kind": {
-                        "const": "CustomMessage"
+                    "kind": {
+                        "const": "CUSTOM_MESSAGE"
                     }
                 }
             },
             "then": {
                 "properties": {
-                    "Kind": {
+                    "kind": {
                         "$ref": "#/$defs/item_messages_kind"
                     },
-                    "Languages": {
+                    "languages": {
                         "$ref": "#/$defs/message_languages"
                     },
-                    "Centered": {
+                    "centered": {
                         "type": "boolean",
                         "default": true
                     }
                 },
                 "required": [
-                    "Languages"
+                    "languages"
                 ],
                 "additionalProperties": false
             },
             "else": {
                 "properties": {
-                    "Kind": {
+                    "kind": {
                         "$ref": "#/$defs/item_messages_kind"
                     },
-                    "MessageID": {
+                    "message_id": {
                         "type": "integer",
                         "minimum": 0,
                         "maximum": 56,
@@ -1009,7 +1009,7 @@
                     }
                 },
                 "required": [
-                    "MessageID"
+                    "message_id"
                 ],
                 "additionalProperties": false
             }
@@ -1017,8 +1017,8 @@
         "item_messages_kind": {
             "type": "string",
             "enum": [
-                "CustomMessage",
-                "MessageID"
+                "CUSTOM_MESSAGE",
+                "MESSAGE_ID"
             ]
         },
         "jingle": {

--- a/src/mars_patcher/zm/hint_text.py
+++ b/src/mars_patcher/zm/hint_text.py
@@ -21,20 +21,9 @@ class HintStatue(IntEnum):
     VARIA_SUIT = auto()
 
 
-LANG_ENUMS = {
-    "JapaneseKanji": Language.JAPANESE_KANJI,
-    "JapaneseHiragana": Language.JAPANESE_HIRAGANA,
-    "English": Language.ENGLISH,
-    "German": Language.GERMAN,
-    "French": Language.FRENCH,
-    "Italian": Language.ITALIAN,
-    "Spanish": Language.SPANISH,
-}
-
-
 def write_intro_text(rom: Rom, data: dict) -> None:
     for lang, text in data.items():
-        lang = LANG_ENUMS[lang]
+        lang = Language[lang]
         base_text_addr = rom.read_ptr(story_text_addr(rom) + lang.value * 4)
         text_ptr = base_text_addr + INTRO_TEXT_ID * 4
         encoded_text = encode_text(rom, MessageType.CONTINUOUS, text)
@@ -43,7 +32,7 @@ def write_intro_text(rom: Rom, data: dict) -> None:
 
 def write_hint_text(rom: Rom, data: dict) -> None:
     for lang, hints in data.items():
-        lang = LANG_ENUMS[lang]
+        lang = Language[lang]
         base_text_addr = rom.read_ptr(message_text_addr(rom) + lang.value * 4)
         for hint, text in hints.items():
             hint = HintStatue[hint]

--- a/src/mars_patcher/zm/locations.py
+++ b/src/mars_patcher/zm/locations.py
@@ -201,5 +201,5 @@ class LocationSettings:
         else:
             loc_obj.hinted_by = HintLocation.NONE
 
-        if "ItemMessages" in loc_entry:
-            loc_obj.item_messages = ItemMessages.from_json(loc_entry["ItemMessages"])
+        if "item_messages" in loc_entry:
+            loc_obj.item_messages = ItemMessages.from_json(loc_entry["item_messages"])

--- a/src/mars_patcher/zm/patcher.py
+++ b/src/mars_patcher/zm/patcher.py
@@ -46,9 +46,9 @@ def patch_zm(
 
     # Randomize palettes - palettes are randomized first since the item
     # patcher needs to copy tilesets
-    if "Palettes" in patch_data:
+    if "palettes" in patch_data:
         status_update("Randomizing palettes...", -1)
-        pal_settings = PaletteSettings.from_json(patch_data["Palettes"])
+        pal_settings = PaletteSettings.from_json(patch_data["palettes"])
         pal_randomizer = PaletteRandomizer(rom, pal_settings)
         pal_randomizer.randomize()
 
@@ -60,9 +60,9 @@ def patch_zm(
     item_patcher.write_items()
 
     # Music
-    if "MusicReplacement" in patch_data:
+    if "music_replacement" in patch_data:
         status_update("Writing music...", -1)
-        set_sounds(rom, patch_data["MusicReplacement"])
+        set_sounds(rom, patch_data["music_replacement"])
 
     # Starting location
     if "starting_location" in patch_data:
@@ -81,13 +81,13 @@ def patch_zm(
 
     # Elevator connections
     # conns = None
-    # if "ElevatorConnections" in patch_data:
+    # if "elevator_connections" in patch_data:
     #     status_update("Writing elevator connections...", -1)
     #     conns = Connections(rom)
-    #     conns.set_elevator_connections(patch_data["ElevatorConnections"])
+    #     conns.set_elevator_connections(patch_data["elevator_connections"])
 
     # Room Names
-    if room_names := patch_data.get("RoomNames", []):
+    if room_names := patch_data.get("room_names", []):
         status_update("Writing room names...", -1)
         write_room_names(rom, room_names)
 
@@ -119,27 +119,27 @@ def patch_zm(
     if patch_data.get("disable_sound_effects"):
         disable_sound_effects(rom)
 
-    # if patch_data.get("UnexploredMap"):
+    # if patch_data.get("unexplored_map"):
     #     apply_unexplored_map(rom)
 
-    #     if not patch_data.get("HideDoorsOnMinimap", False):
+    #     if not patch_data.get("hide_doors_on_minimap", False):
     #         apply_reveal_unexplored_doors(rom)
 
-    # if patch_data.get("RevealHiddenTiles"):
+    # if patch_data.get("reveal_hidden_tiles"):
     #     apply_reveal_hidden_tiles(rom)
 
-    # if "LevelEdits" in patch_data:
-    #     apply_level_edits(rom, patch_data["LevelEdits"])
+    # if "level_edits" in patch_data:
+    #     apply_level_edits(rom, patch_data["level_edits"])
 
     # Apply base minimap edits
     # apply_base_minimap_edits(rom)
 
     # Apply JSON minimap edits
-    # if "MinimapEdits" in patch_data:
-    #     apply_minimap_edits(rom, patch_data["MinimapEdits"])
+    # if "minimap_edits" in patch_data:
+    #     apply_minimap_edits(rom, patch_data["minimap_edits"])
 
     # Door locks
-    # if door_locks := patch_data.get("DoorLocks", []):
+    # if door_locks := patch_data.get("door_locks", []):
     #     status_update("Writing door locks...", -1)
     #     set_door_locks(rom, door_locks)
 


### PR DESCRIPTION
Changes schema fields and constants to use snake_case

Other changes:
- Dictionaries that maps from strings to enums were removed. Enum values are obtained using their name directly
- For the credits line type, White1 and White2 were renamed to WHITE and WHITE_BIG