### PR TITLE
update license field to spdx name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "An open source randomizer patcher for Metroid Fusion."
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "GPL-3.0-only"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
gplv3-only and gplv3-or-later have the same license text to my knowledge, but from what i remember we only ever specified it to be "gplv3" which is synonymous with "3 only"

Fixes #224 